### PR TITLE
Use `rust-cache` on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - uses: Swatinem/rust-cache@v2
       - name: install additional targets
         run: rustup target add wasm32-wasi
       - name: test


### PR DESCRIPTION
[`rust-cache`](https://github.com/Swatinem/rust-cache) can make CI faster. It can not only cache `~/.cargo` and `./target` but also disable incremental compilation and does some other things for fast Rust builds.

ref: https://matklad.github.io/2021/09/04/fast-rust-builds.html