### PR TITLE
feat: add support for fragment type suffix

### DIFF
--- a/crates/config-file/src/config.rs
+++ b/crates/config-file/src/config.rs
@@ -96,6 +96,8 @@ pub struct GenerateNameConfig {
     pub operation_result_type_suffix: Option<String>,
     /// Suffix for type of variables for an operation.
     pub variables_type_suffix: Option<String>,
+    /// Suffix for type of fragment.
+    pub fragment_type_suffix: Option<String>,
     /// Whether operation name should be capitalized.
     pub capitalize_operation_names: Option<bool>,
     /// Suffix for variable of query.

--- a/crates/config-file/src/tests/name.rs
+++ b/crates/config-file/src/tests/name.rs
@@ -9,6 +9,7 @@ schema: schema.graphql
     let name = config.generate.name;
     assert_eq!(name.operation_result_type_suffix, None);
     assert_eq!(name.variables_type_suffix, None);
+    assert_eq!(name.fragment_type_suffix, None);
     assert_eq!(name.capitalize_operation_names, None);
     assert_eq!(name.query_variable_suffix, None);
     assert_eq!(name.mutation_variable_suffix, None);
@@ -28,6 +29,7 @@ extensions:
     let name = config.generate.name;
     assert_eq!(name.operation_result_type_suffix, None);
     assert_eq!(name.variables_type_suffix, None);
+    assert_eq!(name.fragment_type_suffix, None);
     assert_eq!(name.capitalize_operation_names, None);
     assert_eq!(name.query_variable_suffix, None);
     assert_eq!(name.mutation_variable_suffix, None);
@@ -44,6 +46,7 @@ extensions:
             name:
                 operationResultTypeSuffix: Result
                 variablesTypeSuffix: Variables
+                fragmentTypeSuffix: Fragment
                 capitalizeOperationNames: true
                 queryVariableSuffix: Query
                 mutationVariableSuffix: Mutation
@@ -56,6 +59,7 @@ extensions:
         Some("Result".to_string())
     );
     assert_eq!(name.variables_type_suffix, Some("Variables".to_string()));
+    assert_eq!(name.fragment_type_suffix, Some("Fragment".to_string()));
     assert_eq!(name.capitalize_operation_names, Some(true));
     assert_eq!(name.query_variable_suffix, Some("Query".to_string()));
     assert_eq!(name.mutation_variable_suffix, Some("Mutation".to_string()));

--- a/crates/printer/src/operation_type_printer/visitor.rs
+++ b/crates/printer/src/operation_type_printer/visitor.rs
@@ -38,6 +38,8 @@ pub struct OperationTypePrinterOptions {
     pub variables_type_suffix: String,
     /// Suffix for type of operation result.
     pub operation_result_type_suffix: String,
+    /// Suffix for type of fragment.
+    pub fragment_type_suffix: String,
     /// Whether to allow undefined as input value.
     pub allow_undefined_as_optional_input: bool,
 }
@@ -52,6 +54,7 @@ impl Default for OperationTypePrinterOptions {
             typed_document_node_source: "@graphql-typed-document-node/core".to_owned(),
             variables_type_suffix: "Variables".to_owned(),
             operation_result_type_suffix: "Result".to_owned(),
+            fragment_type_suffix: "".to_owned(),
             allow_undefined_as_optional_input: true,
         }
     }
@@ -74,6 +77,10 @@ impl OperationTypePrinterOptions {
         clone_into(
             &config.generate.name.variables_type_suffix,
             &mut result.variables_type_suffix,
+        );
+        clone_into(
+            &config.generate.name.fragment_type_suffix,
+            &mut result.fragment_type_suffix,
         );
         result
     }
@@ -241,7 +248,14 @@ impl<'a, 'src> OperationPrinterVisitor for OperationTypePrinterVisitor<'a, 'src>
             writer.write("export ");
         }
         writer.write("type ");
-        writer.write_for(fragment.name.name, fragment);
+
+        let fragment_name = format!(
+            "{}{}",
+            fragment.name.name, self.options.fragment_type_suffix
+        );
+
+        writer.write_for(&fragment_name, fragment);
+
         writer.write(" = ");
 
         let parent_type = NamedType::from(Node::from(

--- a/packages/core/src/configFormat.ts
+++ b/packages/core/src/configFormat.ts
@@ -89,6 +89,10 @@ export type NitrogqlExtension = {
                */
               variablesTypeSuffix?: string | undefined;
               /**
+               * Suffix for type of fragment.
+               */
+              fragmentTypeSuffix?: string | undefined;
+              /**
                * Whether operation name should be capitalized.
                * @default true
                */

--- a/website/src/app/(docs)/configuration/options/page.tsx
+++ b/website/src/app/(docs)/configuration/options/page.tsx
@@ -439,6 +439,7 @@ export const UserType = {
         capitalizeOperationNames: true
         operationResultTypeSuffix: Result
         variablesTypeSuffix: Variables
+        fragmentTypeSuffix: ''
         queryVariableSuffix: Query
         mutationVariableSuffix: Mutation
         subscriptionVariableSuffix: Subscription`}
@@ -497,6 +498,17 @@ export const UserType = {
           💡 Operation variables type is not visible unless you set{" "}
           <code>export.operationResultType</code> to <code>true</code>.
         </Hint>
+
+        <h4 id="generate.name.fragmentTypeSuffix">fragmentTypeSuffix</h4>
+        <p>
+          Suffix of the fragment type. Default is{" "}
+          <code>&quot;&quot;</code>.
+        </p>
+        <p>
+          For example, if you have <code>fragment PartialUser</code> in your schema,
+          the generated fragment type will be{" "}
+          <code>PartialUserFragment</code>.
+        </p>
 
         <h4 id="generate.name.queryVariableSuffix">queryVariableSuffix</h4>
         <p>


### PR DESCRIPTION
I am currently in the process of migrating from graphql-let to nitrogql at my workplace. One of the tasks involved in this migration is to generate fragment types with a "Fragment" suffix, similar to what graphql-let does. To accomplish this, I have added a function to nitrogql.

This marks my first contribution to this package, so if I have made any mistakes, I would appreciate your feedback and guidance.