### PR TITLE
Fix dependencies version syntax

### DIFF
--- a/packages/esbuild-register/package.json
+++ b/packages/esbuild-register/package.json
@@ -33,7 +33,7 @@
     "vitest": "^0.34.2"
   },
   "dependencies": {
-    "esbuild": ">=0.19.5 && <1",
+    "esbuild": ">=0.19.5 <1",
     "jsonc-parser": "^3.2.0",
     "pirates": "^4.0.6"
   }


### PR DESCRIPTION
Analysis via the [npm SemVer Calculator](https://semver.npmjs.com) indicates that `>=0.19.5 && <1` is not a valid version specification.

![image](https://github.com/uhyo/nitrogql/assets/20186429/f9049a5e-ba00-48c3-968f-98e1dd7e553c)

While npm and Bun accept this notation despite its invalidity, Deno encounters errors due to its inability to accept the `&&`.
This patch might enable nitrogql to work correctly with Deno as well.
