### PR TITLE
fix: add an unimplemented fd_fdstat_get function to wasi

### DIFF
--- a/packages/wasi-preview1/src/api.ts
+++ b/packages/wasi-preview1/src/api.ts
@@ -43,6 +43,7 @@ export type WASIAPI = {
     cookie: bigint,
     ret_buf: number
   ) => number;
+  fd_fdstat_get: (fd: number, ret_buf: number) => number;
   path_filestat_get: (
     fd: number,
     flags: number,

--- a/packages/wasi-preview1/src/wasi.ts
+++ b/packages/wasi-preview1/src/wasi.ts
@@ -303,6 +303,9 @@ export function initWASI(config: WASIConfig): WASIAPI & WASIMeta {
         return handleFsError(e, debug);
       }
     },
+    fd_fdstat_get: (fd, ret_buf) => {
+      throw new Error("Function not implemented.");
+    },
     random_get: (buf, buf_len): number => {
       crypto.randomFillSync(new Uint8Array(memory(), buf, buf_len));
       return 0;


### PR DESCRIPTION

```
LinkError: WebAssembly.instantiate(): Import #16 module="wasi_snapshot_preview1" function="fd_fdstat_get" error: function import requires a callable
    at file:///home/runner/work/nitrogql/nitrogql/packages/cli/bin/main.mjs:40:36
```