### PR TITLE
Fix clippy warnings from Rust 1.96

### DIFF
--- a/crates/ast/src/operation.rs
+++ b/crates/ast/src/operation.rs
@@ -65,7 +65,7 @@ impl HasPos for OperationDefinition<'_> {
 
 impl OperationDefinition<'_> {
     /// Returns Pos for its name.
-    pub fn name_pos(&self) -> NamePos {
+    pub fn name_pos(&self) -> NamePos<'_> {
         match self.name {
             None => NamePos {
                 pos: *self.position(),

--- a/crates/ast/src/type.rs
+++ b/crates/ast/src/type.rs
@@ -28,7 +28,7 @@ impl HasPos for Type<'_> {
 
 impl Type<'_> {
     /// Returns a reference to the unwrapped type of self.
-    pub fn unwrapped_type(&self) -> &NamedType {
+    pub fn unwrapped_type(&self) -> &NamedType<'_> {
         match self {
             Type::Named(name) => name,
             Type::NonNull(inner) => inner.r#type.unwrapped_type(),

--- a/crates/ast/src/type_system.rs
+++ b/crates/ast/src/type_system.rs
@@ -67,7 +67,7 @@ pub enum TypeDefinition<'a> {
 }
 
 impl TypeDefinition<'_> {
-    pub fn name(&self) -> &Ident {
+    pub fn name(&self) -> &Ident<'_> {
         match self {
             TypeDefinition::Scalar(def) => &def.name,
             TypeDefinition::Object(def) => &def.name,

--- a/crates/builtins/src/lib.rs
+++ b/crates/builtins/src/lib.rs
@@ -91,7 +91,7 @@ pub fn generate_builtins() -> Vec<TypeSystemDefinitionOrExtension<'static>> {
         .collect()
 }
 
-fn scalar(name: &str) -> TypeDefinition {
+fn scalar(name: &str) -> TypeDefinition<'_> {
     TypeDefinition::Scalar(ScalarTypeDefinition {
         description: None,
         position: Pos::builtin(),
@@ -133,14 +133,14 @@ fn directive<'a>(
     }
 }
 
-fn ident(name: &str) -> Ident {
+fn ident(name: &str) -> Ident<'_> {
     Ident {
         name,
         position: Pos::builtin(),
     }
 }
 
-fn keyword(name: &str) -> Keyword {
+fn keyword(name: &str) -> Keyword<'_> {
     Keyword {
         name,
         position: Pos::builtin(),

--- a/crates/checker/src/operation_checker/tests/mod.rs
+++ b/crates/checker/src/operation_checker/tests/mod.rs
@@ -1005,11 +1005,11 @@ mod imports {
     }
 }
 
-fn parse_to_type_system_document(source: &str) -> TypeSystemDocument {
+fn parse_to_type_system_document(source: &str) -> TypeSystemDocument<'_> {
     let mut doc = parse_type_system_document(source).unwrap();
     doc.extend(generate_builtins());
-    let doc = resolve_schema_extensions(doc).unwrap();
-    doc
+
+    resolve_schema_extensions(doc).unwrap()
 }
 
 fn test_check(

--- a/crates/checker/src/type_system_checker/tests/mod.rs
+++ b/crates/checker/src/type_system_checker/tests/mod.rs
@@ -1550,11 +1550,11 @@ mod input_objects {
     }
 }
 
-fn parse_to_type_system_document(source: &str) -> TypeSystemDocument {
+fn parse_to_type_system_document(source: &str) -> TypeSystemDocument<'_> {
     use graphql_builtins::generate_builtins;
 
     let mut doc = parse_type_system_document(source).unwrap();
     doc.extend(generate_builtins());
-    let doc = resolve_schema_extensions(doc).unwrap();
-    doc
+
+    resolve_schema_extensions(doc).unwrap()
 }

--- a/crates/checker/src/types.rs
+++ b/crates/checker/src/types.rs
@@ -111,14 +111,13 @@ pub fn is_subtype<'src, S: Text<'src>>(
                     } else {
                         return Some(false);
                     }
-                    if let Some(other_def) = other_def.and_then(|def| def.as_union()) {
-                        if other_def
+                    if let Some(other_def) = other_def.and_then(|def| def.as_union())
+                        && other_def
                             .possible_types
                             .iter()
                             .any(|mem| mem == &***target_name)
-                        {
-                            return Some(true);
-                        }
+                    {
+                        return Some(true);
                     }
                     if other_def.is_some() {
                         Some(false)

--- a/crates/cli/src/builtins.rs
+++ b/crates/cli/src/builtins.rs
@@ -44,14 +44,14 @@ pub fn nitrogql_builtins() -> Vec<TypeSystemDefinitionOrExtension<'static>> {
     )]
 }
 
-fn ident(name: &str) -> Ident {
+fn ident(name: &str) -> Ident<'_> {
     Ident {
         name,
         position: Pos::builtin(),
     }
 }
 
-fn keyword(name: &str) -> Keyword {
+fn keyword(name: &str) -> Keyword<'_> {
     Keyword {
         name,
         position: Pos::builtin(),

--- a/crates/config-file/src/node.rs
+++ b/crates/config-file/src/node.rs
@@ -95,7 +95,7 @@ pub async fn run_node(code: &str) -> io::Result<String> {
                 }
                 RunNodeResult::Error { error } => {
                     let error = serde_json::to_string(&error)?;
-                    Err(io::Error::new(io::ErrorKind::Other, error))
+                    Err(io::Error::other(error))
                 }
             }
         })

--- a/crates/config-file/src/scalar_type.rs
+++ b/crates/config-file/src/scalar_type.rs
@@ -75,7 +75,7 @@ impl ScalarTypeConfig {
         }
     }
     /// Returns this config represented as four separate types.
-    pub fn separate_ref(&self) -> SeparateScalarTypeConfigRef {
+    pub fn separate_ref(&self) -> SeparateScalarTypeConfigRef<'_> {
         match self {
             ScalarTypeConfig::Single(type_name) => SeparateScalarTypeConfigRef {
                 resolver_output: type_name.as_str(),

--- a/crates/graphql-loader/src/tasks.rs
+++ b/crates/graphql-loader/src/tasks.rs
@@ -70,7 +70,7 @@ impl Task {
     }
     /// Gets the root document.
     /// Panics if the root file is not registered yet.
-    pub fn get_root_document(&self) -> (&OperationDocument, &OperationExtension) {
+    pub fn get_root_document(&self) -> (&OperationDocument<'_>, &OperationExtension<'_>) {
         let (doc, extension) = self
             .loaded_files
             .get(&self.root_file_name)
@@ -82,7 +82,10 @@ impl Task {
         self.loaded_files.contains_key(file_name)
     }
     /// Gets the document and extension for the given file.
-    pub fn get_file(&self, file_name: &Path) -> Option<&(OperationDocument, OperationExtension)> {
+    pub fn get_file(
+        &self,
+        file_name: &Path,
+    ) -> Option<&(OperationDocument<'_>, OperationExtension<'_>)> {
         self.loaded_files.get(file_name)
     }
     /// Returns an iterator over loaded files.

--- a/crates/introspection/src/lib.rs
+++ b/crates/introspection/src/lib.rs
@@ -14,7 +14,7 @@ use introspection::IntrospectionResult;
 
 pub fn schema_from_introspection_json<D: Default>(
     source: &str,
-) -> Result<Schema<Cow<str>, D>, IntrospectionError> {
+) -> Result<Schema<Cow<'_, str>, D>, IntrospectionError> {
     let json: IntrospectionResult = serde_json::from_str(source)?;
     introspection::introspection(&json)
 }

--- a/crates/parser/src/parser/mod.rs
+++ b/crates/parser/src/parser/mod.rs
@@ -54,7 +54,7 @@ impl From<ParseError> for PositionedError {
     }
 }
 
-pub fn parse_operation_document(document: &str) -> Result<OperationDocumentExt, ParseError> {
+pub fn parse_operation_document(document: &str) -> Result<OperationDocumentExt<'_>, ParseError> {
     let res = RawParser::parse(Rule::ExecutableDocument, document)?;
 
     Ok(build_operation_document(res))
@@ -62,7 +62,7 @@ pub fn parse_operation_document(document: &str) -> Result<OperationDocumentExt, 
 
 pub fn parse_type_system_document(
     document: &str,
-) -> Result<TypeSystemOrExtensionDocument, ParseError> {
+) -> Result<TypeSystemOrExtensionDocument<'_>, ParseError> {
     let res = RawParser::parse(Rule::TypeSystemExtensionDocument, document)?;
 
     Ok(build_type_system_or_extension_document(res))

--- a/crates/plugin/src/model_plugin/mod.rs
+++ b/crates/plugin/src/model_plugin/mod.rs
@@ -229,10 +229,10 @@ directive @model(
     ) -> Option<TypeSystemDocument<'src>> {
         // removes @model directives
         let definitions = document.definitions.iter().flat_map(|def| {
-            if let TypeSystemDefinition::DirectiveDefinition(def) = def {
-                if def.name.name == "model" {
-                    return None;
-                }
+            if let TypeSystemDefinition::DirectiveDefinition(def) = def
+                && def.name.name == "model"
+            {
+                return None;
             }
             if let TypeSystemDefinition::TypeDefinition(TypeDefinition::Object(def)) = def {
                 let directives = def

--- a/crates/plugin/src/model_plugin/tests/mod.rs
+++ b/crates/plugin/src/model_plugin/tests/mod.rs
@@ -181,7 +181,7 @@ type Post {
     }
 }
 
-fn parse_to_type_system_document(source: &str) -> TypeSystemDocument {
+fn parse_to_type_system_document(source: &str) -> TypeSystemDocument<'_> {
     let mut doc = parse_type_system_document(source).unwrap();
     doc.extend(generate_builtins());
 
@@ -195,8 +195,7 @@ fn parse_to_type_system_document(source: &str) -> TypeSystemDocument {
             .flat_map(|d| d.definitions),
     );
 
-    let doc = resolve_schema_extensions(doc).unwrap();
-    doc
+    resolve_schema_extensions(doc).unwrap()
 }
 
 struct TestHost {}

--- a/crates/printer/src/operation_js_printer/tests/mod.rs
+++ b/crates/printer/src/operation_js_printer/tests/mod.rs
@@ -167,7 +167,7 @@ fn can_print_mutually_recursive_fragments() {
     assert_snapshot!(print_js(&document));
 }
 
-fn parse(str: &str) -> OperationDocument {
+fn parse(str: &str) -> OperationDocument<'_> {
     let doc = parse_operation_document(str).unwrap();
     let (document, _) = resolve_operation_extensions(doc).unwrap();
     document

--- a/crates/printer/src/operation_type_printer/tests/mod.rs
+++ b/crates/printer/src/operation_type_printer/tests/mod.rs
@@ -64,8 +64,8 @@ fn type_system() -> TypeSystemDocument<'static> {
     )
     .unwrap();
     doc.extend(generate_builtins());
-    let doc = resolve_schema_extensions(doc).unwrap();
-    doc
+
+    resolve_schema_extensions(doc).unwrap()
 }
 
 #[test]

--- a/crates/printer/src/operation_type_printer/type_printer.rs
+++ b/crates/printer/src/operation_type_printer/type_printer.rs
@@ -349,10 +349,8 @@ fn check_skip_directive<'src, S: Text<'src>>(
                             return true;
                         }
                     }
-                    Value::BooleanValue(b) => {
-                        if b.value {
-                            return true;
-                        }
+                    Value::BooleanValue(b) if b.value => {
+                        return true;
                     }
                     _ => {}
                 }
@@ -375,10 +373,8 @@ fn check_skip_directive<'src, S: Text<'src>>(
                             return true;
                         }
                     }
-                    Value::BooleanValue(b) => {
-                        if !b.value {
-                            return true;
-                        }
+                    Value::BooleanValue(b) if !b.value => {
+                        return true;
                     }
                     _ => {}
                 }

--- a/crates/printer/src/schema_type_printer/context.rs
+++ b/crates/printer/src/schema_type_printer/context.rs
@@ -65,7 +65,7 @@ fn get_scalar_types(
             let directive_ts_type = definition
                 .directives
                 .iter()
-                .find(|directive| (directive.name.name == "nitrogql_ts_type"))
+                .find(|directive| directive.name.name == "nitrogql_ts_type")
                 .and_then(|directive| directive.arguments.as_ref())
                 .and_then(|args| {
                     let mut resolver_input_type = None;

--- a/crates/semantics/src/definition_map.rs
+++ b/crates/semantics/src/definition_map.rs
@@ -22,7 +22,7 @@ pub struct DefinitionMap<'a> {
 
 impl DefinitionMap<'_> {
     /// Returns a TypeDefinition for the root type of given OperationType.
-    pub fn root_type(&self, op: OperationType) -> Option<&TypeDefinition> {
+    pub fn root_type(&self, op: OperationType) -> Option<&TypeDefinition<'_>> {
         let op_type_name = match self.schema {
             Some(schema) => schema
                 .definitions

--- a/crates/semantics/src/schema_extension_resolver/extension_list.rs
+++ b/crates/semantics/src/schema_extension_resolver/extension_list.rs
@@ -64,7 +64,7 @@ impl From<ExtensionError> for PositionedError {
 }
 
 impl<OriginalType: HasPos, ExtensionType: HasPos> ExtensionList<'_, OriginalType, ExtensionType> {
-    pub fn new(name_of_elem: &str) -> ExtensionList<OriginalType, ExtensionType> {
+    pub fn new(name_of_elem: &str) -> ExtensionList<'_, OriginalType, ExtensionType> {
         ExtensionList {
             name_of_elem,
             items: IndexMap::new(),

--- a/crates/semantics/src/type_system_to_ast.rs
+++ b/crates/semantics/src/type_system_to_ast.rs
@@ -16,7 +16,7 @@ use nitrogql_ast::{
 };
 
 /// Convert Schema to TypeSystemDocument. For type definition generation purpose.
-pub fn type_system_to_ast<'src, S: Text<'src>, D>(schema: &Schema<S, D>) -> TypeSystemDocument {
+pub fn type_system_to_ast<'src, S: Text<'src>, D>(schema: &Schema<S, D>) -> TypeSystemDocument<'_> {
     let mut result = TypeSystemDocument::new();
     let schema_definition = {
         let mut schema_definition = SchemaDefinition {
@@ -62,7 +62,7 @@ pub fn type_system_to_ast<'src, S: Text<'src>, D>(schema: &Schema<S, D>) -> Type
 
 fn convert_type_definition<S: Deref<Target = str>, D>(
     type_def: &graphql_type_system::TypeDefinition<S, D>,
-) -> TypeDefinition {
+) -> TypeDefinition<'_> {
     match type_def {
         graphql_type_system::TypeDefinition::Scalar(scalar) => {
             TypeDefinition::Scalar(ScalarTypeDefinition {
@@ -152,7 +152,7 @@ fn convert_type_definition<S: Deref<Target = str>, D>(
 
 fn convert_field<S: Deref<Target = str>, D>(
     field: &graphql_type_system::Field<S, D>,
-) -> FieldDefinition {
+) -> FieldDefinition<'_> {
     FieldDefinition {
         description: convert_description(&field.description),
         name: convert_node_to_ident(&field.name),
@@ -162,7 +162,7 @@ fn convert_field<S: Deref<Target = str>, D>(
     }
 }
 
-fn convert_type<S: Deref<Target = str>, D>(ty: &graphql_type_system::Type<S, D>) -> Type {
+fn convert_type<S: Deref<Target = str>, D>(ty: &graphql_type_system::Type<S, D>) -> Type<'_> {
     match ty {
         graphql_type_system::Type::Named(named) => Type::Named(NamedType {
             name: convert_node_to_ident(named),
@@ -179,7 +179,7 @@ fn convert_type<S: Deref<Target = str>, D>(ty: &graphql_type_system::Type<S, D>)
 
 fn convert_arguments<S: Deref<Target = str>, D>(
     arguments: &[graphql_type_system::InputValue<S, D>],
-) -> Option<ArgumentsDefinition> {
+) -> Option<ArgumentsDefinition<'_>> {
     if arguments.is_empty() {
         None
     } else {
@@ -191,7 +191,7 @@ fn convert_arguments<S: Deref<Target = str>, D>(
 
 fn convert_input_value<S: Deref<Target = str>, D>(
     input_value: &graphql_type_system::InputValue<S, D>,
-) -> InputValueDefinition {
+) -> InputValueDefinition<'_> {
     InputValueDefinition {
         description: convert_description(&input_value.description),
         position: Pos::default(),
@@ -217,14 +217,14 @@ fn convert_description<S: Deref<Target = str>, D>(
     })
 }
 
-fn convert_node_to_ident<S: Deref<Target = str>, D>(node: &Node<S, D>) -> Ident {
+fn convert_node_to_ident<S: Deref<Target = str>, D>(node: &Node<S, D>) -> Ident<'_> {
     Ident {
         name: node,
         position: Pos::default(),
     }
 }
 
-fn keyword(name: &str) -> Keyword {
+fn keyword(name: &str) -> Keyword<'_> {
     Keyword {
         name,
         position: Pos::builtin(),

--- a/crates/sourcemap-writer/src/js_string_writer.rs
+++ b/crates/sourcemap-writer/src/js_string_writer.rs
@@ -11,7 +11,7 @@ pub struct JsStringWriter<'a> {
 }
 
 impl JsStringWriter<'_> {
-    pub fn new(buffer: &mut String) -> JsStringWriter {
+    pub fn new(buffer: &mut String) -> JsStringWriter<'_> {
         buffer.push_str("`\n");
         JsStringWriter {
             buffer,

--- a/crates/sourcemap-writer/src/just_writer.rs
+++ b/crates/sourcemap-writer/src/just_writer.rs
@@ -10,7 +10,7 @@ pub struct JustWriter<'a> {
 }
 
 impl JustWriter<'_> {
-    pub fn new(buffer: &mut String) -> JustWriter {
+    pub fn new(buffer: &mut String) -> JustWriter<'_> {
         JustWriter {
             buffer,
             indent: 0,


### PR DESCRIPTION
Apply machine-applicable fixes surfaced by the Rust 1.96 toolchain:
- mismatched_lifetime_syntaxes: add explicit '_ lifetimes
- collapsible_if: merge nested ifs into let-chains
- let_and_return, unused_parens, io_other_error, collapsible_match