### PR TITLE
fix: handle fd_fdstat_get on preopened directories in WASI

### DIFF
--- a/packages/wasi-preview1/src/fs.ts
+++ b/packages/wasi-preview1/src/fs.ts
@@ -108,7 +108,12 @@ export class FileSystem {
    */
   stat(fd: FD): nodeFs.BigIntStats {
     if (fd.hostFd === undefined) {
-      throw new FSError("Not opened", "badf");
+      // Preopened directories do not have a host file descriptor, so stat the
+      // host path directly. (Rust's std calls fd_fdstat_get on preopened
+      // directories during startup.)
+      return this.#fs.statSync(fd.hostPath, {
+        bigint: true,
+      });
     }
     return this.#fs.fstatSync(fd.hostFd, {
       bigint: true,

--- a/packages/wasi-preview1/src/tests/wasi.test.ts
+++ b/packages/wasi-preview1/src/tests/wasi.test.ts
@@ -372,6 +372,62 @@ describe("fs", () => {
       assertFileStat(memory.buffer, 128, 7, 11n);
     });
   });
+  describe("fd_fdstat_get", () => {
+    it("should return stats for preopened directory", () => {
+      const fs = createTestFS({
+        "/app": {
+          "foo.txt": "hello world",
+        },
+      });
+      const wasi = initWASI({
+        args: [],
+        env: {},
+        preopens: { "/": "/app" },
+        fs,
+      });
+      wasi.setMemory(memory);
+
+      // fd 3 is the preopened directory, which has no host file descriptor.
+      const result = wasi.fd_fdstat_get(3, 256);
+      expect(result).toBe(0);
+      // filetype::directory
+      expect(buffer.getUint8(256)).toBe(3);
+    });
+    it("should return stats for opened file", () => {
+      const fs = createTestFS({
+        "/app": {
+          "foo.txt": "hello world",
+        },
+      });
+      const wasi = initWASI({
+        args: [],
+        env: {},
+        preopens: { "/": "/app" },
+        fs,
+      });
+      wasi.setMemory(memory);
+
+      writeTextToBuf("foo.txt", memory.buffer);
+      const result = wasi.path_open(3, 0, 0, 7, 0, 0, 0, 0, 64);
+      expect(result).toBe(0);
+      const fd = buffer.getUint32(64, true);
+      const result2 = wasi.fd_fdstat_get(fd, 256);
+      expect(result2).toBe(0);
+      // filetype::regular_file
+      expect(buffer.getUint8(256)).toBe(4);
+    });
+    it("should return badf when fd is not open", () => {
+      const fs = createTestFS({
+        "/app": {
+          "foo.txt": "hello world",
+        },
+      });
+      const wasi = initWASI({ args: [], env: {}, preopens: {}, fs });
+      wasi.setMemory(memory);
+      const result = wasi.fd_fdstat_get(4, 256);
+      expect(result).toBe(8);
+    });
+  });
   describe("fd_read", () => {
     // Waiting for https://github.com/streamich/memfs/pull/946
     it.skip("should read from file", () => {


### PR DESCRIPTION
## Problem

The e2e tests fail at the first step — `nitrogql generate` exits immediately with:

```
Error:
Bad file descriptor (os error 8)
```

The CLI runs as a `wasm32-wasip1` module hosted by the hand-written WASI preview1 implementation in `packages/wasi-preview1`. With `NODE_DEBUG=wasi` the failing syscall is clear:

```
fd_prestat_get(3, ...) = 0
fd_fdstat_get(3, ...) = 8     # 8 = EBADF
```

`fd_fdstat_get` (added in #55) calls `FileSystem.stat()`, which threw `badf` whenever a fd had no host file descriptor. Preopened directories (fd 3, 4, …) only carry a host *path*, never a host fd — so the stat blew up.

This surfaced now because of the toolchain upgrade (migrate to Rust 2024 / Rust 1.96). Newer Rust std calls `fd_fdstat_get` on the preopened directory during startup, which earlier toolchains didn't.

Note: in CI only `e2e-test (Node 20.5)` shows as failed — the other matrix jobs were *cancelled* by fail-fast once 20.5 failed first. It is not Node-version-specific.

## Fix

In `FileSystem.stat`, fall back to stat'ing the host path when a fd has no host descriptor:

```ts
stat(fd: FD): nodeFs.BigIntStats {
  if (fd.hostFd === undefined) {
    // Preopened directories do not have a host file descriptor, so stat the
    // host path directly. (Rust's std calls fd_fdstat_get on preopened
    // directories during startup.)
    return this.#fs.statSync(fd.hostPath, { bigint: true });
  }
  return this.#fs.fstatSync(fd.hostFd, { bigint: true });
}
```

This also makes `fd_filestat_get` work on preopened directories.

## Verification

- `nitrogql generate` now succeeds; the full `e2e-tests` suite (cjs/esm/node16) passes.
- The nextjs and vite example `generate` steps pass.
- Added 3 regression tests for `fd_fdstat_get` (preopened directory, opened file, unopened fd → badf). WASI unit tests: **35 passed, 4 skipped**.

## Note

While adding tests I hit a pre-existing fragility: the WASI test suite shares a single module-level `WebAssembly.Memory` across tests, so test order and scratch offsets matter. I worked around it by writing the new tests' scratch data to a clean offset. Filed separately as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoCQ47XnG2dYvS9MxGj8dC)_