### PR TITLE
test(wasi): isolate WASI tests with a fresh memory per test

### DIFF
--- a/packages/wasi-preview1/src/tests/wasi.test.ts
+++ b/packages/wasi-preview1/src/tests/wasi.test.ts
@@ -1,11 +1,17 @@
 import { Volume, createFsFromVolume } from "memfs";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { initWASI } from "../wasi.js";
 import { NestedDirectoryJSON } from "memfs";
 
-// 1 is 64KiB
-const memory = new WebAssembly.Memory({ initial: 1 });
-const buffer = new DataView(memory.buffer);
+// Each test gets a fresh memory so that leftover bytes at fixed offsets can
+// never couple one test to another. See #60.
+let memory: WebAssembly.Memory;
+let buffer: DataView;
+beforeEach(() => {
+  // 1 is 64KiB
+  memory = new WebAssembly.Memory({ initial: 1 });
+  buffer = new DataView(memory.buffer);
+});
 
 describe("args", () => {
   it("args_sizes_get", () => {

--- a/packages/wasi-preview1/src/wasi.ts
+++ b/packages/wasi-preview1/src/wasi.ts
@@ -256,6 +256,12 @@ export function initWASI(config: WASIConfig): WASIAPI & WASIMeta {
       iovs_len: number,
       ret_buf: number
     ): number => {
+      // Validate the fd before reading iovs from guest memory, so that a bad
+      // fd never depends on (or touches) whatever happens to sit at iovs_ptr.
+      // stdout (1) and stderr (2) are always writable.
+      if (fd !== 1 && fd !== 2 && fs.get(fd) === undefined) {
+        return error.badf;
+      }
       const buffers = [];
       const dv = new DataView(memory(), iovs_ptr, 8 * iovs_len);
       for (let i = 0; i < iovs_len; i++) {


### PR DESCRIPTION
Each test in wasi.test.ts shared a single module-level WebAssembly.Memory
that was never reset, coupling tests through leftover bytes at fixed
offsets. Give each test a fresh memory via a beforeEach factory so offsets
can be reused freely without invisible ordering dependencies.

Also validate the fd in fd_write before reading iovs from guest memory, so
the "badf" path no longer depends on (or touches) whatever sits at iovs_ptr.

Fixes #60.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETG6mDwjvVZQvoHTZQ6M7T