### PR TITLE
ci: modernize Node.js version matrix to current LTS lines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 20.5 is added because @nitrogql/esbuild-register behaves differently
-        # before and after 20.6
-        # 18.18 is added for the same reason
-        node-version: [18.18, 18, 20.5, 20, 22]
+        node-version: [22, 24]
     name: e2e-test (Node ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
     name: unit-test-js (Node ${{ matrix.node-version }})
     strategy:
       matrix:
-        node-version: [18.18, 18, 20.5, 20, 22]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
     name: e2e-test (Node ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

The `unit-test-js` and `e2e-test` CI jobs were pinned to an outdated Node.js matrix that included versions now past end-of-life. This modernizes both to the current LTS lines plus the latest release.

Both jobs now test `[22, 24, 26]`:

| Version | Status (as of June 2026) |
|---------|--------------------------|
| **22** (Jod) | Maintenance LTS |
| **24** | Active LTS |
| **26** | Current release (becomes LTS Oct 2026) |

## Changes

| Job | Before | After |
|-----|--------|-------|
| `unit-test-js` | `[18.18, 18, 20.5, 20, 22]` | `[22, 24, 26]` |
| `e2e-test` | `[18.18, 18, 20.5, 20, 22]` | `[22, 24, 26]` |

Node 18 (EOL April 2025) and Node 20 (EOL April 2026) were dropped. The special-cased minor versions (`18.18`, `20.5`) and their comment — which probed `@nitrogql/esbuild-register` behavior on either side of the Node 20.6 boundary — were also removed, since every version in the new matrix is well past that boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPcxp4r9quU5co9mqUkGVm)_