### PR TITLE
Remove dead old-Node fallback in @nitrogql/core

### DIFF
--- a/packages/core/src/command/commandClient.ts
+++ b/packages/core/src/command/commandClient.ts
@@ -1,10 +1,6 @@
-import child_process from "node:child_process";
-import * as module from "node:module";
 import { Worker } from "node:worker_threads";
 import { once } from "node:events";
 import path from "node:path";
-import readline from "node:readline";
-import { fileURLToPath } from "node:url";
 
 export type CommandClient = {
   /**
@@ -16,17 +12,6 @@ export type CommandClient = {
 };
 
 export function getCommandClient(): CommandClient {
-  // @nitrogql/esbuild-register requires different usage
-  // depending on whether Node.js supports the `register` API from `node:module`.
-  const nodeHasModuleRegisterAPI = !!module.register;
-  if (nodeHasModuleRegisterAPI) {
-    return getWorkerCommandClient();
-  } else {
-    return getProcessCommandClient();
-  }
-}
-
-function getWorkerCommandClient(): CommandClient {
   const w = new Worker(new URL("./server.js", import.meta.url), {
     env: {
       ...process.env,
@@ -52,50 +37,6 @@ function getWorkerCommandClient(): CommandClient {
     },
     close: () => {
       w.terminate();
-    },
-  };
-}
-
-function getProcessCommandClient(): CommandClient {
-  const childProcess = child_process.spawn(
-    process.execPath,
-    [
-      "--no-warnings",
-      "--require=@nitrogql/esbuild-register",
-      "--experimental-loader=@nitrogql/esbuild-register/hook",
-      fileURLToPath(new URL("./server.js", import.meta.url)),
-    ],
-    {
-      stdio: ["pipe", "pipe", "inherit"],
-      env: {
-        ...process.env,
-        DATA_URL_RESOLUTION_BASE: path.join(process.cwd(), "__entrypoint__"),
-      },
-    },
-  );
-  childProcess.on("error", (error) => {
-    console.error(error);
-  });
-  childProcess.on("exit", () => {
-    console.error("Child process exited");
-  });
-  const rl = readline.createInterface({
-    input: childProcess.stdout,
-    output: childProcess.stdin,
-  });
-  return {
-    run: async (command: string) => {
-      const commandString = JSON.stringify(command);
-      childProcess.stdin.write(commandString + "\n");
-      const [line] = await once(rl, "line");
-      const result = JSON.parse(line);
-      if (result.error) {
-        throw result.error;
-      }
-      return result.result;
-    },
-    close: () => {
-      childProcess.kill();
     },
   };
 }

--- a/packages/core/src/command/server.ts
+++ b/packages/core/src/command/server.ts
@@ -1,5 +1,3 @@
-import readline from "node:readline";
-import { stdout, stdin } from "node:process";
 import inspector from "node:inspector";
 import { parentPort } from "node:worker_threads";
 import { CommandRunner } from "./commandRunner.js";
@@ -8,57 +6,35 @@ const commandRunner = new CommandRunner();
 // console.error("CommandRunner started", process.version);
 
 if (parentPort === null) {
-  // standalone server mode
-  const rl = readline.createInterface({
-    input: stdin,
-  });
-
-  rl.on("line", (line) => {
-    // console.error("Got line:", line);
-    const parsed = JSON.parse(line);
-    if (typeof parsed !== "string") {
-      console.error("Input must be a JSON string");
-      return;
-    }
-    commandRunner.run(parsed);
-  });
-} else {
-  // https://github.com/nodejs/node/issues/26609
-  if (process.execArgv.includes("--inspect-brk")) {
-    inspector.open();
-    inspector.waitForDebugger();
-    debugger;
-  }
-
-  // worker mode
-  parentPort.on("message", (message) => {
-    // console.error("Got message:", message);
-    if (typeof message !== "string") {
-      console.error("Input must be a string");
-      return;
-    }
-    commandRunner.run(message);
-  });
+  throw new Error("This module must be run as a worker thread");
 }
+
+// https://github.com/nodejs/node/issues/26609
+if (process.execArgv.includes("--inspect-brk")) {
+  inspector.open();
+  inspector.waitForDebugger();
+  debugger;
+}
+
+parentPort.on("message", (message) => {
+  // console.error("Got message:", message);
+  if (typeof message !== "string") {
+    console.error("Input must be a string");
+    return;
+  }
+  commandRunner.run(message);
+});
 
 for await (const result of commandRunner.output) {
   // console.error("Got result:", result);
   if (result.error) {
     console.error(result.error);
-    if (parentPort !== null) {
-      parentPort.postMessage({
-        error: result.error,
-      });
-    } else {
-      stdout.write(JSON.stringify({ error: result.error }) + "\n");
-    }
+    parentPort.postMessage({
+      error: result.error,
+    });
   } else {
-    if (parentPort !== null) {
-      parentPort.postMessage({
-        result: result.result,
-      });
-    } else {
-      stdout.write(JSON.stringify({ result: result.result }) + "\n");
-    }
+    parentPort.postMessage({
+      result: result.result,
+    });
   }
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -13,35 +13,11 @@ import { getCommandClient } from "./command/commandClient.js";
  * @returns stdout
  */
 export function executeNodeSync(code: string): string {
-  const nodeVersion = process.versions.node;
-  // @nitrogql/esbuild-register requires different usage
-  // depending on whether Node.js supports the `register` API from `node:module`.
-  const [major, minor] = nodeVersion.split(".").map((x) => Number(x)) as [
-    number,
-    number,
-  ];
-  const nodeHasModuleRegisterAPI =
-    major > 20 || (major === 20 && minor >= 6) || (major === 18 && minor >= 19);
-  if (nodeHasModuleRegisterAPI) {
-    return execFileSync(
-      process.execPath,
-      [
-        "--no-warnings",
-        "--import=@nitrogql/esbuild-register",
-        "--input-type=module",
-      ],
-      {
-        encoding: "utf-8",
-        input: code,
-      },
-    );
-  }
   return execFileSync(
     process.execPath,
     [
       "--no-warnings",
-      "--require=@nitrogql/esbuild-register",
-      "--experimental-loader=@nitrogql/esbuild-register/hook",
+      "--import=@nitrogql/esbuild-register",
       "--input-type=module",
     ],
     {


### PR DESCRIPTION
Follow-up from #70. Removes the dead old-Node (`< 20.6.0` / `< 18.19.0`) `--require=@nitrogql/esbuild-register` / `--experimental-loader` fallback from `@nitrogql/core`, always using the `--import` path.

## Why it was safe to remove

After #70 dropped esbuild-register's CommonJS entrypoint, `--require=@nitrogql/esbuild-register` resolves to ESM — which `require()` can't load on the old Node versions that actually trigger this branch. On every supported version (`module.register` exists), the `--import` path is always taken, so the fallback was unreachable.

## Changes

- **`packages/core/src/config.ts`** — `executeNodeSync` always uses `--import=@nitrogql/esbuild-register`; dropped the Node version-parsing / `nodeHasModuleRegisterAPI` check.
- **`packages/core/src/command/commandClient.ts`** — `getCommandClient` always uses the worker-thread client. Removed the `module.register` branch, `getProcessCommandClient`, and the now-unused `child_process`, `node:module`, `readline`, and `fileURLToPath` imports (inlined the trivial `getWorkerCommandClient` wrapper too).
- **`packages/core/src/command/server.ts`** — dropped the standalone stdin/stdout server mode that only the removed process client used; the server now always runs as a worker (throws if it isn't), removing the `readline` / `stdin` plumbing.

Net: `3 files changed, 23 insertions(+), 130 deletions(-)`.

## Verification

- `npm run check --workspaces --if-present` — passes
- `npm test --workspaces --if-present` — passes (142 tests)
- Built rust + node and ran `npm run e2e-test --workspace ./e2e-tests` — all three suites (cjs / esm / node16) pass, exercising the config-loading paths changed here

The `esbuild-register` README's old-Node section was left alone, since the issue scopes esbuild-register changes to #70.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtALLbq9MX2kFey9ot4TXt)_