### PR TITLE
Pin Rust toolchain version and automate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
       - name: install rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - uses: Swatinem/rust-cache@v2
-      - name: install additional targets
-        run: rustup target add wasm32-wasip1
       - name: test
         run: cargo test
       - name: lint
@@ -53,8 +51,6 @@ jobs:
       - name: install rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - uses: Swatinem/rust-cache@v2
-      - name: install additional targets
-        run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/update-rust.yaml
+++ b/.github/workflows/update-rust.yaml
@@ -1,0 +1,51 @@
+name: Update Rust toolchain
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC. Rust stable ships every ~6 weeks, so this
+    # picks up new releases within a few days without being noisy.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine latest stable Rust version
+        id: latest
+        run: |
+          rustup toolchain install stable --profile minimal >/dev/null
+          version="$(rustc +stable --version | awk '{print $2}')"
+          echo "Latest stable: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Read currently pinned version
+        id: current
+        run: |
+          version="$(grep -E '^channel = ' rust-toolchain.toml | sed -E 's/.*"(.*)".*/\1/')"
+          echo "Currently pinned: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Update rust-toolchain.toml
+        if: steps.latest.outputs.version != steps.current.outputs.version
+        run: |
+          sed -i -E "s/^channel = \".*\"/channel = \"${{ steps.latest.outputs.version }}\"/" rust-toolchain.toml
+      - name: Create Pull Request
+        if: steps.latest.outputs.version != steps.current.outputs.version
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Update Rust toolchain to ${{ steps.latest.outputs.version }}"
+          title: "Update Rust toolchain to ${{ steps.latest.outputs.version }}"
+          body: |
+            A new stable Rust release is available.
+
+            - Pinned: `${{ steps.current.outputs.version }}`
+            - Latest stable: `${{ steps.latest.outputs.version }}`
+
+            This PR bumps `rust-toolchain.toml`. Merge once CI is green.
+          branch: update-rust-toolchain
+          base: master
+          delete-branch: true
+          labels: dependencies

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+[toolchain]
+# Pin the Rust toolchain so CI (and local builds) use a known version.
+# A new compiler release can break the build even without code changes,
+# so we upgrade this deliberately. The "Update Rust toolchain" workflow
+# (.github/workflows/update-rust.yaml) opens a PR when a newer stable is out.
+channel = "1.94.1"
+profile = "minimal"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-wasip1", "wasm32-unknown-unknown"]


### PR DESCRIPTION
## Why

CI installed the latest stable Rust on every run, so a new compiler release could break the build without any code change on our side. This pins the version and makes upgrades deliberate.

## What

- **Pin the version** via `rust-toolchain.toml` (`channel = "1.94.1"`). rustup honors this automatically, so both CI and local builds use the same toolchain — no changes to the CI commands themselves were required. The file also declares `clippy`/`rustfmt` components and the `wasm32-wasip1` / `wasm32-unknown-unknown` targets the build needs.
- **Drop redundant CI steps**: the explicit `rustup target add ...` steps are removed, since rustup now installs those targets automatically from `rust-toolchain.toml`.
- **Automate Rust upgrades**: a new scheduled workflow (`.github/workflows/update-rust.yaml`, weekly + manual dispatch) checks for a newer stable Rust and, if found, opens a PR bumping the pinned version — so updates land as reviewed, CI-checked PRs.
- **Dependabot**: added `.github/dependabot.yml` to keep GitHub Actions versions up to date weekly.

## Note for the maintainer

The update workflow opens PRs via `GITHUB_TOKEN`. For that to work, enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SF7GeqCjnJAG4XfrD77iNb)_