### PR TITLE
Add support for the @oneOf directive

### DIFF
--- a/crates/builtins/src/lib.rs
+++ b/crates/builtins/src/lib.rs
@@ -65,6 +65,7 @@ pub fn generate_builtins() -> Vec<TypeSystemDefinitionOrExtension<'static>> {
                 "ENUM_VALUE",
             ],
         ),
+        directive("oneOf", vec![], vec!["INPUT_OBJECT"]),
         directive(
             "specifiedBy",
             vec![(

--- a/crates/checker/src/common.rs
+++ b/crates/checker/src/common.rs
@@ -287,6 +287,48 @@ fn is_value_compatible_type_def<'src, S: Text<'src>>(
                 }
                 return (false, vec![]);
             };
+            if object_def.one_of {
+                if value.fields.len() != 1 {
+                    result.push(
+                        CheckErrorMessage::OneOfInputNotExactlyOneField {
+                            name: object_def.name.to_string(),
+                        }
+                        .with_pos(value.position)
+                        .with_additional_info(vec![(
+                            *object_def.name.original_node_ref(),
+                            CheckErrorMessage::DefinitionPos {
+                                name: object_def.name.to_string(),
+                            },
+                        )]),
+                    );
+                } else {
+                    let (key, field_value) = &value.fields[0];
+                    match field_value {
+                        Value::NullValue(_) => {
+                            result.push(
+                                CheckErrorMessage::OneOfInputNullValue {
+                                    field: key.name.to_owned(),
+                                }
+                                .with_pos(*field_value.position()),
+                            );
+                        }
+                        Value::Variable(variable) => {
+                            // Unknown variable is reported by the recursive check_value
+                            if let Some(v_def) = get_variable_definition(variables, variable)
+                                && !v_def.r#type.is_nonnull()
+                            {
+                                result.push(
+                                    CheckErrorMessage::OneOfInputNullableVariable {
+                                        name: variable.name.to_owned(),
+                                    }
+                                    .with_pos(*field_value.position()),
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
             let mut res = true;
             let mut additional_info = vec![];
             let mut seen_fields = 0;

--- a/crates/checker/src/error.rs
+++ b/crates/checker/src/error.rs
@@ -90,6 +90,10 @@ pub enum CheckErrorMessage {
     ArgumentTypeNonNullAgainstInterface { interface_name: String },
     #[error("'{member_name}' is not an object type")]
     NonObjectTypeUnionMember { member_name: String },
+    #[error("Field of @oneOf input object must not be of non-null type")]
+    OneOfFieldNotNullable,
+    #[error("Field of @oneOf input object must not have a default value")]
+    OneOfFieldWithDefaultValue,
     // errors for operation
     #[error("Unnamed operation must be the only operation in this document")]
     UnNamedOperationMustBeSingle,
@@ -120,6 +124,14 @@ pub enum CheckErrorMessage {
     RecursingFragmentSpread { name: String },
     #[error("Subscription operation must have exactly one root field")]
     SubscriptionMustHaveExactlyOneRootField,
+    #[error("Value of @oneOf input object '{name}' must have exactly one field")]
+    OneOfInputNotExactlyOneField { name: String },
+    #[error("Field '{field}' of @oneOf input object must not be null")]
+    OneOfInputNullValue { field: String },
+    #[error(
+        "Variable '${name}' used for a field of @oneOf input object must be of non-null type"
+    )]
+    OneOfInputNullableVariable { name: String },
     // Error that should be checked in type system check phase
     #[error("Type system error. This is a bug of checker")]
     TypeSystemError,

--- a/crates/checker/src/operation_checker/tests/mod.rs
+++ b/crates/checker/src/operation_checker/tests/mod.rs
@@ -1005,6 +1005,143 @@ mod imports {
     }
 }
 
+mod one_of {
+    use std::borrow::Cow;
+
+    use graphql_type_system::Schema;
+    use insta::assert_debug_snapshot;
+    use nitrogql_semantics::ast_to_type_system;
+
+    use nitrogql_ast::base::Pos;
+    use nitrogql_parser::parse_operation_document;
+
+    use super::{parse_to_type_system_document, test_check};
+
+    fn type_system() -> Schema<Cow<'static, str>, Pos> {
+        let doc = parse_to_type_system_document(
+            "
+            type Query {
+                user(by: UserBy!): User
+            }
+            type User {
+                id: ID!
+                name: String!
+            }
+            input UserBy @oneOf {
+                id: ID
+                email: String
+            }
+        ",
+        );
+        ast_to_type_system(&doc)
+    }
+
+    #[test]
+    fn valid_single_field() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query {
+                user(by: { id: \"123\" }) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+
+    #[test]
+    fn two_fields() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query {
+                user(by: { id: \"123\", email: \"foo@example.com\" }) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+
+    #[test]
+    fn no_fields() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query {
+                user(by: {}) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+
+    #[test]
+    fn null_field() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query {
+                user(by: { id: null }) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+
+    #[test]
+    fn nullable_variable_field() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query ($id: ID) {
+                user(by: { id: $id }) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+
+    #[test]
+    fn non_null_variable_field() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query ($id: ID!) {
+                user(by: { id: $id }) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+
+    #[test]
+    fn whole_input_variable() {
+        let schema = type_system();
+        let doc = parse_operation_document(
+            "
+            query ($by: UserBy!) {
+                user(by: $by) { name }
+            }
+        ",
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(test_check(schema, doc));
+    }
+}
+
 fn parse_to_type_system_document(source: &str) -> TypeSystemDocument<'_> {
     let mut doc = parse_type_system_document(source).unwrap();
     doc.extend(generate_builtins());

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__no_fields.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__no_fields.snap
@@ -1,0 +1,30 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[
+    CheckError {
+        position: Pos {
+            line: 2,
+            column: 25,
+            file: 0,
+            builtin: false,
+        },
+        message: OneOfInputNotExactlyOneField {
+            name: "UserBy",
+        },
+        additional_info: [
+            (
+                Pos {
+                    line: 8,
+                    column: 18,
+                    file: 0,
+                    builtin: false,
+                },
+                DefinitionPos {
+                    name: "UserBy",
+                },
+            ),
+        ],
+    },
+]

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__non_null_variable_field.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__non_null_variable_field.snap
@@ -1,0 +1,5 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[]

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__null_field.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__null_field.snap
@@ -1,0 +1,18 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[
+    CheckError {
+        position: Pos {
+            line: 2,
+            column: 31,
+            file: 0,
+            builtin: false,
+        },
+        message: OneOfInputNullValue {
+            field: "id",
+        },
+        additional_info: [],
+    },
+]

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__nullable_variable_field.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__nullable_variable_field.snap
@@ -1,0 +1,18 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[
+    CheckError {
+        position: Pos {
+            line: 2,
+            column: 31,
+            file: 0,
+            builtin: false,
+        },
+        message: OneOfInputNullableVariable {
+            name: "id",
+        },
+        additional_info: [],
+    },
+]

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__two_fields.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__two_fields.snap
@@ -1,0 +1,30 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[
+    CheckError {
+        position: Pos {
+            line: 2,
+            column: 25,
+            file: 0,
+            builtin: false,
+        },
+        message: OneOfInputNotExactlyOneField {
+            name: "UserBy",
+        },
+        additional_info: [
+            (
+                Pos {
+                    line: 8,
+                    column: 18,
+                    file: 0,
+                    builtin: false,
+                },
+                DefinitionPos {
+                    name: "UserBy",
+                },
+            ),
+        ],
+    },
+]

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__valid_single_field.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__valid_single_field.snap
@@ -1,0 +1,5 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[]

--- a/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__whole_input_variable.snap
+++ b/crates/checker/src/operation_checker/tests/snapshots/nitrogql_checker__operation_checker__tests__one_of__whole_input_variable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/checker/src/operation_checker/tests/mod.rs
+expression: "test_check(schema, doc)"
+---
+[]

--- a/crates/checker/src/type_system_checker/mod.rs
+++ b/crates/checker/src/type_system_checker/mod.rs
@@ -406,6 +406,7 @@ fn check_input_object(
         result,
     );
 
+    let is_one_of = input.directives.iter().any(|d| d.name.name == "oneOf");
     let mut seen_fields = vec![];
     for f in input.fields.iter() {
         if seen_fields.contains(&f.name.name) {
@@ -452,6 +453,20 @@ fn check_input_object(
                 );
             }
             Some(false) => {}
+        }
+
+        if is_one_of {
+            if f.r#type.is_nonnull() {
+                result.push(
+                    CheckErrorMessage::OneOfFieldNotNullable.with_pos(*f.r#type.position()),
+                );
+            }
+            if let Some(ref default_value) = f.default_value {
+                result.push(
+                    CheckErrorMessage::OneOfFieldWithDefaultValue
+                        .with_pos(*default_value.position()),
+                );
+            }
         }
     }
 }

--- a/crates/checker/src/type_system_checker/tests/mod.rs
+++ b/crates/checker/src/type_system_checker/tests/mod.rs
@@ -1550,6 +1550,139 @@ mod input_objects {
     }
 }
 
+#[cfg(test)]
+mod one_of {
+    use insta::assert_debug_snapshot;
+
+    use crate::type_system_checker::{
+        check_type_system_document, tests::parse_to_type_system_document,
+    };
+
+    #[test]
+    fn valid_one_of_input_object() {
+        let doc = parse_to_type_system_document(
+            "
+            input UserBy @oneOf {
+                id: ID
+                email: String
+            }
+        ",
+        );
+        let errors = check_type_system_document(&doc);
+        assert_debug_snapshot!(errors, @"[]");
+    }
+
+    #[test]
+    fn one_of_field_must_be_nullable() {
+        let doc = parse_to_type_system_document(
+            "
+            input UserBy @oneOf {
+                id: ID!
+                email: String
+            }
+        ",
+        );
+        let errors = check_type_system_document(&doc);
+        assert_debug_snapshot!(errors, @"
+        [
+            CheckError {
+                position: Pos {
+                    line: 2,
+                    column: 20,
+                    file: 0,
+                    builtin: false,
+                },
+                message: OneOfFieldNotNullable,
+                additional_info: [],
+            },
+        ]
+        ");
+    }
+
+    #[test]
+    fn one_of_field_must_not_have_default_value() {
+        let doc = parse_to_type_system_document(
+            "
+            input UserBy @oneOf {
+                id: ID = \"admin\"
+                email: String
+            }
+        ",
+        );
+        let errors = check_type_system_document(&doc);
+        assert_debug_snapshot!(errors, @"
+        [
+            CheckError {
+                position: Pos {
+                    line: 2,
+                    column: 25,
+                    file: 0,
+                    builtin: false,
+                },
+                message: OneOfFieldWithDefaultValue,
+                additional_info: [],
+            },
+        ]
+        ");
+    }
+
+    #[test]
+    fn one_of_wrong_location() {
+        let doc = parse_to_type_system_document(
+            "
+            type MyType @oneOf {
+                foo: String
+            }
+        ",
+        );
+        let errors = check_type_system_document(&doc);
+        assert_debug_snapshot!(errors, @r#"
+        [
+            CheckError {
+                position: Pos {
+                    line: 1,
+                    column: 24,
+                    file: 0,
+                    builtin: false,
+                },
+                message: DirectiveLocationNotAllowed {
+                    name: "oneOf",
+                },
+                additional_info: [],
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn one_of_applied_by_extension() {
+        let doc = parse_to_type_system_document(
+            "
+            input UserBy {
+                id: ID
+                email: String!
+            }
+            extend input UserBy @oneOf
+        ",
+        );
+        let errors = check_type_system_document(&doc);
+        assert_debug_snapshot!(errors, @"
+        [
+            CheckError {
+                position: Pos {
+                    line: 3,
+                    column: 23,
+                    file: 0,
+                    builtin: false,
+                },
+                message: OneOfFieldNotNullable,
+                additional_info: [],
+            },
+        ]
+        ");
+    }
+}
+
 fn parse_to_type_system_document(source: &str) -> TypeSystemDocument<'_> {
     use graphql_builtins::generate_builtins;
 

--- a/crates/introspection/src/introspection.rs
+++ b/crates/introspection/src/introspection.rs
@@ -49,6 +49,8 @@ struct IntrospectionType<'src> {
     input_fields: Option<Vec<IntrospectionInputValue<'src>>>,
     #[serde(rename = "ofType")]
     of_type: Option<Box<IntrospectionType<'src>>>,
+    #[serde(rename = "isOneOf")]
+    is_one_of: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -299,6 +301,7 @@ fn as_type_definition<'src, D: Default>(
             name,
             description,
             fields,
+            one_of: value.is_one_of.unwrap_or(false),
         }))
     } else {
         Err(IntrospectionError::Introspection(format!(

--- a/crates/introspection/src/tests/mod.rs
+++ b/crates/introspection/src/tests/mod.rs
@@ -1337,3 +1337,115 @@ fn read_introspection() {
     schema.print_graphql(&mut writer);
     assert_snapshot!(buffer);
 }
+
+#[test]
+fn read_introspection_one_of() {
+    let json = r#"{
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "user",
+              "description": null,
+              "args": [
+                {
+                  "name": "by",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UserBy",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UserBy",
+          "description": "Input for looking up a user.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "email",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "isOneOf": true
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": []
+    }
+}"#;
+    let schema = schema_from_introspection_json::<()>(json).unwrap();
+
+    let mut buffer = String::new();
+    let mut writer = JustWriter::new(&mut buffer);
+    schema.print_graphql(&mut writer);
+    assert_snapshot!(buffer);
+}

--- a/crates/introspection/src/tests/snapshots/nitrogql_introspection__tests__read_introspection_one_of.snap
+++ b/crates/introspection/src/tests/snapshots/nitrogql_introspection__tests__read_introspection_one_of.snap
@@ -1,0 +1,21 @@
+---
+source: crates/introspection/src/tests/mod.rs
+expression: buffer
+---
+schema {
+  query: Query
+}
+
+type Query {
+  user(by: UserBy!): String
+}
+
+"Input for looking up a user."
+input UserBy @oneOf {
+  id: ID
+  email: String
+}
+
+scalar ID
+
+scalar String

--- a/crates/printer/src/graphql_printer/schema.rs
+++ b/crates/printer/src/graphql_printer/schema.rs
@@ -144,6 +144,9 @@ impl<'a, Str: Text<'a>, OriginalNode> GraphQLPrinter for TypeDefinition<Str, Ori
             TypeDefinition::InputObject(object) => {
                 writer.write("input ");
                 writer.write(&object.name);
+                if object.one_of {
+                    writer.write(" @oneOf");
+                }
                 writer.write(" {\n");
                 writer.indent();
                 for field in object.fields.iter() {

--- a/crates/printer/src/schema_type_printer/tests/mod.rs
+++ b/crates/printer/src/schema_type_printer/tests/mod.rs
@@ -272,6 +272,59 @@ fn deprecated_items() {
 }
 
 #[test]
+fn one_of_input_object() {
+    let doc = parse_type_system_document(
+        r#"
+        scalar ID
+        scalar String
+        scalar Int
+
+        input UserBy @oneOf {
+            id: ID
+            "Email address of user."
+            email: String
+            registrationNumber: Int @deprecated(reason: "Use id instead")
+        }
+
+        type Query {
+            me: String!
+        }
+        "#,
+    )
+    .unwrap();
+    let doc = resolve_schema_extensions(doc).unwrap();
+    let printed = print_document(&doc, SchemaTypePrinterOptions::default()).unwrap();
+    assert_snapshot!(printed);
+}
+
+#[test]
+fn one_of_input_object_with_input_nullable_field_is_optional_false() {
+    let doc = parse_type_system_document(
+        r#"
+        scalar ID
+        scalar String
+
+        input UserBy @oneOf {
+            id: ID
+            email: String
+        }
+
+        type Query {
+            me: String!
+        }
+        "#,
+    )
+    .unwrap();
+    let doc = resolve_schema_extensions(doc).unwrap();
+    let options = SchemaTypePrinterOptions {
+        input_nullable_field_is_optional: false,
+        ..SchemaTypePrinterOptions::default()
+    };
+    let printed = print_document(&doc, options).unwrap();
+    assert_snapshot!(printed);
+}
+
+#[test]
 fn enum_runtime() {
     let doc = parse_type_system_document(
         r#"

--- a/crates/printer/src/schema_type_printer/tests/snapshots/nitrogql_printer__schema_type_printer__tests__one_of_input_object.snap
+++ b/crates/printer/src/schema_type_printer/tests/snapshots/nitrogql_printer__schema_type_printer__tests__one_of_input_object.snap
@@ -1,0 +1,113 @@
+---
+source: crates/printer/src/schema_type_printer/tests/mod.rs
+expression: printed
+---
+export type __nitrogql_schema = {
+  query: Query;
+};
+
+type __Beautify<Obj> = { [K in keyof Obj]: Obj[K] } & {};
+export type __SelectionSet<Orig, Obj, Others> =
+  __Beautify<Pick<{
+    [K in keyof Orig]: Obj extends { [P in K]?: infer V } ? V : unknown
+  }, Extract<keyof Orig, keyof Obj>> & Others>;
+
+export declare namespace __OperationInput {
+  export type ID = string | number;
+
+  export type String = string;
+
+  export type Int = number;
+
+
+  export type UserBy = {
+    readonly id: ID;
+    readonly email?: never;
+    readonly registrationNumber?: never;
+  } | {
+    readonly id?: never;
+    /**
+     * Email address of user.
+     */
+    readonly email: String;
+    readonly registrationNumber?: never;
+  } | {
+    readonly id?: never;
+    readonly email?: never;
+    /**
+     * @deprecated Use id instead
+     */
+    readonly registrationNumber: Int;
+  };
+
+}
+
+export declare namespace __OperationOutput {
+  export type ID = string;
+
+  export type String = string;
+
+  export type Int = number;
+
+  export type Query = {
+    __typename: "Query";
+    me: String;
+  };
+
+
+}
+
+export declare namespace __ResolverInput {
+  export type ID = string;
+
+  export type String = string;
+
+  export type Int = number;
+
+
+  export type UserBy = {
+    readonly id: ID;
+    readonly email?: never;
+    readonly registrationNumber?: never;
+  } | {
+    readonly id?: never;
+    /**
+     * Email address of user.
+     */
+    readonly email: String;
+    readonly registrationNumber?: never;
+  } | {
+    readonly id?: never;
+    readonly email?: never;
+    /**
+     * @deprecated Use id instead
+     */
+    readonly registrationNumber: Int;
+  };
+
+}
+
+export declare namespace __ResolverOutput {
+  export type ID = string | number;
+
+  export type String = string;
+
+  export type Int = number;
+
+  export type Query = {
+    __typename: "Query";
+    me: String;
+  };
+
+
+}
+
+export type ID = __OperationOutput.ID;
+
+export type String = __OperationOutput.String;
+
+export type Int = __OperationOutput.Int;
+
+export type Query = __OperationOutput.Query;
+
+export type UserBy = __ResolverInput.UserBy;

--- a/crates/printer/src/schema_type_printer/tests/snapshots/nitrogql_printer__schema_type_printer__tests__one_of_input_object_with_input_nullable_field_is_optional_false.snap
+++ b/crates/printer/src/schema_type_printer/tests/snapshots/nitrogql_printer__schema_type_printer__tests__one_of_input_object_with_input_nullable_field_is_optional_false.snap
@@ -1,0 +1,79 @@
+---
+source: crates/printer/src/schema_type_printer/tests/mod.rs
+expression: printed
+---
+export type __nitrogql_schema = {
+  query: Query;
+};
+
+type __Beautify<Obj> = { [K in keyof Obj]: Obj[K] } & {};
+export type __SelectionSet<Orig, Obj, Others> =
+  __Beautify<Pick<{
+    [K in keyof Orig]: Obj extends { [P in K]?: infer V } ? V : unknown
+  }, Extract<keyof Orig, keyof Obj>> & Others>;
+
+export declare namespace __OperationInput {
+  export type ID = string | number;
+
+  export type String = string;
+
+
+  export type UserBy = {
+    readonly id: ID;
+    readonly email?: never;
+  } | {
+    readonly id?: never;
+    readonly email: String;
+  };
+
+}
+
+export declare namespace __OperationOutput {
+  export type ID = string;
+
+  export type String = string;
+
+  export type Query = {
+    __typename: "Query";
+    me: String;
+  };
+
+
+}
+
+export declare namespace __ResolverInput {
+  export type ID = string;
+
+  export type String = string;
+
+
+  export type UserBy = {
+    readonly id: ID;
+    readonly email?: never;
+  } | {
+    readonly id?: never;
+    readonly email: String;
+  };
+
+}
+
+export declare namespace __ResolverOutput {
+  export type ID = string | number;
+
+  export type String = string;
+
+  export type Query = {
+    __typename: "Query";
+    me: String;
+  };
+
+
+}
+
+export type ID = __OperationOutput.ID;
+
+export type String = __OperationOutput.String;
+
+export type Query = __OperationOutput.Query;
+
+export type UserBy = __ResolverInput.UserBy;

--- a/crates/printer/src/schema_type_printer/type_printer.rs
+++ b/crates/printer/src/schema_type_printer/type_printer.rs
@@ -2,7 +2,9 @@ use std::{borrow::Borrow, fmt::Display};
 
 use crate::{
     ts_types::{
-        ObjectField, TSType, ts_types_util::ts_union, type_to_ts_type::get_ts_type_of_type,
+        ObjectField, TSType,
+        ts_types_util::ts_union,
+        type_to_ts_type::{get_ts_type_of_type, get_ts_type_of_type_non_null},
     },
     utils::interface_implementers,
 };
@@ -407,43 +409,94 @@ impl TypePrinter for InputObjectTypeDefinition<'_> {
             return Ok(());
         }
         let schema_type = context.schema.get_type(self.name.name);
-        let obj_type = TSType::Object(
-            self.fields
-                .iter()
-                .map(|field| {
-                    let schema_field = schema_type
-                        .and_then(|t| t.as_input_object())
-                        .and_then(|t| t.fields.iter().find(|f| f.name == field.name.name))
-                        .expect("Type system error");
+        let is_one_of = self.directives.iter().any(|d| d.name.name == "oneOf");
+        let obj_type = if is_one_of {
+            // A @oneOf input object is printed as a union of
+            // single-field object types.
+            ts_union(self.fields.iter().enumerate().map(|(selected_index, _)| {
+                TSType::Object(
+                    self.fields
+                        .iter()
+                        .enumerate()
+                        .map(|(index, field)| {
+                            if index != selected_index {
+                                return ObjectField {
+                                    key: (&field.name).into(),
+                                    r#type: TSType::Never,
+                                    readonly: true,
+                                    optional: true,
+                                    description: None,
+                                };
+                            }
+                            let schema_field = schema_type
+                                .and_then(|t| t.as_input_object())
+                                .and_then(|t| {
+                                    t.fields.iter().find(|f| f.name == field.name.name)
+                                })
+                                .expect("Type system error");
 
-                    let ts_type = get_ts_type_of_type(&field.r#type, |name| {
-                        let local_name = context
-                            .local_type_names
-                            .get(name.name.name)
-                            .expect("Local type name not generated");
-                        TSType::TypeVariable(local_name.as_str().into())
+                            // The selected field must be given a non-null value.
+                            let ts_type = get_ts_type_of_type_non_null(&field.r#type, |name| {
+                                let local_name = context
+                                    .local_type_names
+                                    .get(name.name.name)
+                                    .expect("Local type name not generated");
+                                TSType::TypeVariable(local_name.as_str().into())
+                            })
+                            .into_readonly();
+                            ObjectField {
+                                key: (&field.name).into(),
+                                r#type: ts_type,
+                                readonly: true,
+                                optional: false,
+                                description: make_ts_description(
+                                    &field.description,
+                                    &schema_field.deprecation,
+                                ),
+                            }
+                        })
+                        .collect(),
+                )
+            }))
+        } else {
+            TSType::Object(
+                self.fields
+                    .iter()
+                    .map(|field| {
+                        let schema_field = schema_type
+                            .and_then(|t| t.as_input_object())
+                            .and_then(|t| t.fields.iter().find(|f| f.name == field.name.name))
+                            .expect("Type system error");
+
+                        let ts_type = get_ts_type_of_type(&field.r#type, |name| {
+                            let local_name = context
+                                .local_type_names
+                                .get(name.name.name)
+                                .expect("Local type name not generated");
+                            TSType::TypeVariable(local_name.as_str().into())
+                        })
+                        .into_readonly();
+                        let is_optional = context.options.input_nullable_field_is_optional
+                            && !field.r#type.is_nonnull();
+                        let ts_type = if is_optional {
+                            TSType::Union(vec![ts_type, TSType::Undefined])
+                        } else {
+                            ts_type
+                        };
+                        ObjectField {
+                            key: (&field.name).into(),
+                            r#type: ts_type,
+                            readonly: true,
+                            optional: is_optional,
+                            description: make_ts_description(
+                                &field.description,
+                                &schema_field.deprecation,
+                            ),
+                        }
                     })
-                    .into_readonly();
-                    let is_optional = context.options.input_nullable_field_is_optional
-                        && !field.r#type.is_nonnull();
-                    let ts_type = if is_optional {
-                        TSType::Union(vec![ts_type, TSType::Undefined])
-                    } else {
-                        ts_type
-                    };
-                    ObjectField {
-                        key: (&field.name).into(),
-                        r#type: ts_type,
-                        readonly: true,
-                        optional: is_optional,
-                        description: make_ts_description(
-                            &field.description,
-                            &schema_field.deprecation,
-                        ),
-                    }
-                })
-                .collect(),
-        );
+                    .collect(),
+            )
+        };
 
         print_description(&self.description, writer);
         let local_name = context

--- a/crates/printer/src/ts_types/type_to_ts_type.rs
+++ b/crates/printer/src/ts_types/type_to_ts_type.rs
@@ -11,6 +11,16 @@ pub fn get_ts_type_of_type(ty: &Type, map_name: impl FnOnce(&NamedType) -> TSTyp
     }
 }
 
+/// Variant of `get_ts_type_of_type` that does not add `| null`
+/// even if given type is nullable.
+pub fn get_ts_type_of_type_non_null(
+    ty: &Type,
+    map_name: impl FnOnce(&NamedType) -> TSType,
+) -> TSType {
+    let (ty, _) = get_ts_type_of_type_impl(ty, map_name);
+    ty
+}
+
 /// With nullability flag
 fn get_ts_type_of_type_impl(
     ty: &Type,

--- a/crates/semantics/src/ast_to_type_system.rs
+++ b/crates/semantics/src/ast_to_type_system.rs
@@ -157,6 +157,7 @@ fn convert_type_definition<'src>(
                                 deprecation: convert_deprecation(&input.directives),
                             })
                             .collect(),
+                        one_of: convert_one_of(&def.directives),
                     }),
                     def.position,
                 ),
@@ -224,6 +225,10 @@ fn convert_field<'src>(field: &FieldDefinition<'src>) -> Field<Cow<'src, str>, P
         arguments: convert_arguments(&field.arguments),
         deprecation: convert_deprecation(&field.directives),
     }
+}
+
+fn convert_one_of(directives: &[Directive]) -> bool {
+    directives.iter().any(|dir| dir.name.name == "oneOf")
 }
 
 fn convert_deprecation<'src>(directives: &[Directive<'src>]) -> Option<Cow<'src, str>> {

--- a/crates/semantics/src/tests/mod.rs
+++ b/crates/semantics/src/tests/mod.rs
@@ -344,6 +344,115 @@ fn introspection_to_ast() {
     assert_snapshot!(print_ast(&ast));
 }
 
+#[test]
+fn introspection_to_ast_one_of() {
+    let json = r#"{
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "user",
+              "description": null,
+              "args": [
+                {
+                  "name": "by",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UserBy",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UserBy",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "email",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "isOneOf": true
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": []
+    }
+}"#;
+    let schema = schema_from_introspection_json::<()>(json).unwrap();
+    let ast = type_system_to_ast(&schema);
+    assert_snapshot!(print_ast(&ast));
+}
+
 fn print_ast(ast: &TypeSystemDocument) -> String {
     let mut buf = String::new();
     let mut writer = JustWriter::new(&mut buf);

--- a/crates/semantics/src/tests/snapshots/nitrogql_semantics__tests__introspection_to_ast_one_of.snap
+++ b/crates/semantics/src/tests/snapshots/nitrogql_semantics__tests__introspection_to_ast_one_of.snap
@@ -1,0 +1,16 @@
+---
+source: crates/semantics/src/tests/mod.rs
+expression: print_ast(&ast)
+---
+schema {
+  query: Query
+}
+type Query {
+  user(by: UserBy!): String
+}
+input UserBy @oneOf {
+  id: ID
+  email: String
+}
+scalar ID
+scalar String

--- a/crates/semantics/src/type_system_to_ast.rs
+++ b/crates/semantics/src/type_system_to_ast.rs
@@ -4,6 +4,7 @@ use graphql_type_system::{Node, Schema, Text};
 use nitrogql_ast::{
     TypeSystemDocument,
     base::{Ident, Keyword, Pos},
+    directive::Directive,
     operation::OperationType,
     r#type::{ListType, NamedType, NonNullType, Type},
     type_system::{
@@ -138,7 +139,15 @@ fn convert_type_definition<S: Deref<Target = str>, D>(
                 description: convert_description(&input_object.description),
                 position: Pos::default(),
                 name: convert_node_to_ident(&input_object.name),
-                directives: vec![],
+                directives: if input_object.one_of {
+                    vec![Directive {
+                        position: Pos::builtin(),
+                        name: ident("oneOf"),
+                        arguments: None,
+                    }]
+                } else {
+                    vec![]
+                },
                 input_keyword: keyword("input"),
                 fields: input_object
                     .fields
@@ -226,6 +235,13 @@ fn convert_node_to_ident<S: Deref<Target = str>, D>(node: &Node<S, D>) -> Ident<
 
 fn keyword(name: &str) -> Keyword<'_> {
     Keyword {
+        name,
+        position: Pos::builtin(),
+    }
+}
+
+fn ident(name: &str) -> Ident<'_> {
+    Ident {
         name,
         position: Pos::builtin(),
     }

--- a/crates/type-system/src/definitions.rs
+++ b/crates/type-system/src/definitions.rs
@@ -110,6 +110,7 @@ where
                     name: def.name.as_ref().map(&f),
                     description: map_option_node(&def.description, &f),
                     fields: def.fields.iter().map(|x| x.map_str(&f)).collect(),
+                    one_of: def.one_of,
                 })
             }
         }
@@ -195,6 +196,8 @@ pub struct InputObjectDefinition<Str, OriginalNode> {
     pub description: Option<Node<Str, OriginalNode>>,
     /// Field definitions.
     pub fields: Vec<InputValue<Str, OriginalNode>>,
+    /// Whether this input object is a @oneOf input object.
+    pub one_of: bool,
 }
 
 /// Represents one field in an object type.


### PR DESCRIPTION
Implements the [`@oneOf` directive](https://spec.graphql.org/draft/#sec--oneOf) for input object types as specified in the GraphQL draft spec.

## Changes

### Built-in directive
- `@oneOf` is now defined as a built-in directive on the `INPUT_OBJECT` location (`crates/builtins`). Location/repeat validation comes for free from the existing directive checker.
- The lowered type system's `InputObjectDefinition` gained a `one_of: bool` flag, populated from the directive during AST → type-system lowering. Applying `@oneOf` via `extend input` also works since extension directives merge before lowering.

### Schema validation
In `check_input_object`, when a type is marked `@oneOf`:
- each field must be of nullable type → `OneOfFieldNotNullable`
- fields must not have default values → `OneOfFieldWithDefaultValue`

### Operation validation
In input-object value checking, when the target type is `@oneOf`:
- a literal value must have exactly one field → `OneOfInputNotExactlyOneField` (with a pointer to the type definition)
- that field's value must not be `null` → `OneOfInputNullValue`
- a variable used for the field must be declared with a non-null type → `OneOfInputNullableVariable` (matching graphql-js's static strictness; passing a whole variable of the input type remains valid)

### TypeScript generation
A `@oneOf` input object is printed as a union of single-field variants. The selected key is required and non-null; all other keys are typed `?: never` for excess-key safety:

```ts
export type UserBy = {
  readonly id: ID;
  readonly email?: never;
} | {
  readonly id?: never;
  readonly email: String;
};
```

The `input_nullable_field_is_optional` option deliberately does not apply to `@oneOf` variants, since the spec requires the selected field to be present and non-null. Field descriptions and `@deprecated` JSDoc are preserved per variant.

### Introspection
`isOneOf` is read from introspection JSON and round-trips through the type system back to an `@oneOf` directive in both SDL printing and AST regeneration, so schemas loaded from introspection get the same validation and type generation.

## Tests
- 16 new tests across four suites: SDL checker (inline snapshots), operation checker, schema type printer, and introspection round-trip.
- All pre-existing tests pass with zero snapshot churn; clippy is clean.
- Verified end-to-end with the CLI: `check` reports `@oneOf` violations with correct source positions, `generate` emits the union type into the `.d.ts`, and a user-supplied `directive @oneOf on INPUT_OBJECT` declaration coexists without duplicate-definition errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3gvvcjvAxHjUdHhpyxwLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3gvvcjvAxHjUdHhpyxwLn)_