### PR TITLE
Support descriptions on operations, fragments and variable definitions

### DIFF
--- a/crates/ast/src/operation.rs
+++ b/crates/ast/src/operation.rs
@@ -4,6 +4,7 @@ use super::{
     base::{HasPos, Ident, NamePos, Pos},
     directive::Directive,
     selection_set::SelectionSet,
+    value::StringValue,
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -47,6 +48,7 @@ impl HasPos for ExecutableDefinition<'_> {
 #[derive(Clone, Debug)]
 pub struct OperationDefinition<'a> {
     pub position: Pos,
+    pub description: Option<StringValue>,
     pub operation_type: OperationType,
     pub name: Option<Ident<'a>>,
     pub variables_definition: Option<VariablesDefinition<'a>>,
@@ -82,6 +84,7 @@ impl OperationDefinition<'_> {
 #[derive(Clone, Debug)]
 pub struct FragmentDefinition<'a> {
     pub position: Pos,
+    pub description: Option<StringValue>,
     pub name: Ident<'a>,
     pub type_condition: Ident<'a>,
     pub directives: Vec<Directive<'a>>,

--- a/crates/ast/src/variable.rs
+++ b/crates/ast/src/variable.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{HasPos, Pos},
     directive::Directive,
     r#type::Type,
-    value::Value,
+    value::{StringValue, Value},
 };
 
 /// Variable token.
@@ -32,6 +32,7 @@ pub struct VariablesDefinition<'a> {
 #[derive(Clone, Debug)]
 pub struct VariableDefinition<'a> {
     pub pos: Pos,
+    pub description: Option<StringValue>,
     pub name: Variable<'a>,
     pub r#type: Type<'a>,
     pub default_value: Option<Value<'a>>,

--- a/crates/parser/src/parser/builder/operation.rs
+++ b/crates/parser/src/parser/builder/operation.rs
@@ -11,6 +11,7 @@ use super::{
     directives::build_directives,
     selection_set::build_selection_set,
     r#type::build_type,
+    type_system::build_description,
     utils::PairExt,
     value::{build_string_value, build_value},
 };
@@ -29,8 +30,9 @@ pub fn build_variables_definition(pair: Pair<Rule>) -> VariablesDefinition {
 /// Parses one VariableDefinition Pair.
 pub fn build_variable_definition(pair: Pair<Rule>) -> VariableDefinition {
     let pos = pair.to_pos();
-    let (variable, ty, default_value, directives) = parts!(
+    let (description, variable, ty, default_value, directives) = parts!(
         pair,
+        Description opt,
         Variable,
         Type,
         DefaultValue opt,
@@ -39,6 +41,7 @@ pub fn build_variable_definition(pair: Pair<Rule>) -> VariableDefinition {
 
     VariableDefinition {
         pos,
+        description: description.map(build_description),
         name: build_variable(variable),
         r#type: build_type(ty),
         default_value: default_value.map(|pair| {
@@ -55,8 +58,16 @@ pub fn build_executable_definition(pair: Pair<Rule>) -> ExecutableDefinitionExt 
     match pair.as_rule() {
         Rule::OperationDefinition => {
             // TODO: handling of OperationSet (abbreviated syntax)
-            let (operation_type, name, variables_definition, directives, selection_set) = parts!(
+            let (
+                description,
+                operation_type,
+                name,
+                variables_definition,
+                directives,
+                selection_set,
+            ) = parts!(
                 pair,
+                Description opt,
                 OperationType,
                 Name opt,
                 VariablesDefinition opt,
@@ -65,6 +76,7 @@ pub fn build_executable_definition(pair: Pair<Rule>) -> ExecutableDefinitionExt 
             );
             ExecutableDefinitionExt::OperationDefinition(OperationDefinition {
                 position,
+                description: description.map(build_description),
                 operation_type: str_to_operation_type(operation_type.as_str()),
                 name: name.map(|pair| pair.to_ident()),
                 variables_definition: variables_definition.map(build_variables_definition),
@@ -73,8 +85,9 @@ pub fn build_executable_definition(pair: Pair<Rule>) -> ExecutableDefinitionExt 
             })
         }
         Rule::FragmentDefinition => {
-            let (_, name, type_condition, directives, selection_set) = parts!(
+            let (description, _, name, type_condition, directives, selection_set) = parts!(
                 pair,
+                Description opt,
                 KEYWORD_fragment,
                 FragmentName,
                 TypeCondition,
@@ -83,6 +96,7 @@ pub fn build_executable_definition(pair: Pair<Rule>) -> ExecutableDefinitionExt 
             );
             ExecutableDefinitionExt::FragmentDefinition(FragmentDefinition {
                 position,
+                description: description.map(build_description),
                 name: name.to_ident(),
                 type_condition: {
                     let (_, name) = parts!(type_condition, KEYWORD_on, NamedType);

--- a/crates/parser/src/parser/grammar.pest
+++ b/crates/parser/src/parser/grammar.pest
@@ -85,7 +85,7 @@ ExecutableDocument = { SOI ~ ExecutableDefinition+ ~ EOI }
 
 ExecutableDefinition = { OperationDefinition | FragmentDefinition | ext_ImportStatement }
 OperationDefinition = {
-  OperationType ~ Name? ~ VariablesDefinition? ~ Directives? ~ SelectionSet | SelectionSet
+  Description? ~ OperationType ~ Name? ~ VariablesDefinition? ~ Directives? ~ SelectionSet | SelectionSet
 }
 
 OperationType = { KEYWORD_query | KEYWORD_mutation| KEYWORD_subscription }
@@ -101,7 +101,7 @@ Argument = { Name ~ ":" ~ Value }
 FragmentSpread = { "..." ~ FragmentName ~ Directives? }
 InlineFragment = { "..." ~ TypeCondition? ~ Directives? ~ SelectionSet }
 
-FragmentDefinition = { KEYWORD_fragment ~ FragmentName ~ TypeCondition ~ Directives? ~ SelectionSet }
+FragmentDefinition = { Description? ~ KEYWORD_fragment ~ FragmentName ~ TypeCondition ~ Directives? ~ SelectionSet }
 
 FragmentName = { !KEYWORD_on ~ Name }
 TypeCondition = { KEYWORD_on ~ NamedType }
@@ -133,7 +133,7 @@ ObjectValue = {
 ObjectField = { Name ~ ":" ~ Value }
 
 VariablesDefinition = { "(" ~ VariableDefinition+ ~ ")" }
-VariableDefinition = { Variable ~ ":" ~ Type ~ DefaultValue? ~ Directives? }
+VariableDefinition = { Description? ~ Variable ~ ":" ~ Type ~ DefaultValue? ~ Directives? }
 
 Variable = { "$" ~ Name }
 

--- a/crates/parser/src/tests/mod.rs
+++ b/crates/parser/src/tests/mod.rs
@@ -90,6 +90,35 @@ mod operation {
         ));
     }
     #[test]
+    fn descriptions() {
+        assert_snapshot!(print_graphql(
+            parse_operation_document(
+                r#"
+                "This is a query."
+                query sample(
+                    "This is a variable."
+                    $foo: Int!
+                    """
+                    This is another variable.
+                    """
+                    $bar: String = "bar" @deprecated
+                ) {
+                    foo
+                    ...F
+                }
+                """
+                This is a fragment.
+                """
+                fragment F on Foo {
+                    bar
+                }
+                "#
+            )
+            .unwrap()
+        ));
+    }
+
+    #[test]
     fn comments() {
         assert_snapshot!(print_graphql(
             parse_operation_document(

--- a/crates/parser/src/tests/snapshots/nitrogql_parser__tests__operation__descriptions.snap
+++ b/crates/parser/src/tests/snapshots/nitrogql_parser__tests__operation__descriptions.snap
@@ -1,0 +1,20 @@
+---
+source: crates/parser/src/tests/mod.rs
+expression: "print_graphql(parse_operation_document(r#\"\n                \"This is a query.\"\n                query sample(\n                    \"This is a variable.\"\n                    $foo: Int!\n                    \"\"\"\n                    This is another variable.\n                    \"\"\"\n                    $bar: String = \"bar\" @deprecated\n                ) {\n                    foo\n                    ...F\n                }\n                \"\"\"\n                This is a fragment.\n                \"\"\"\n                fragment F on Foo {\n                    bar\n                }\n                \"#).unwrap())"
+---
+"This is a query."
+query sample(
+  "This is a variable." $foo: Int!,
+  """
+                      This is another variable.
+                      """ $bar: String
+) {
+  foo
+  ... F
+}
+"""
+                This is a fragment.
+                """
+fragment F on Foo {
+  bar
+}

--- a/crates/printer/src/graphql_printer/ast.rs
+++ b/crates/printer/src/graphql_printer/ast.rs
@@ -44,6 +44,10 @@ impl GraphQLPrinter for ExecutableDefinition<'_> {
 
 impl GraphQLPrinter for OperationDefinition<'_> {
     fn print_graphql(&self, writer: &mut impl SourceMapWriter) {
+        if let Some(ref description) = self.description {
+            description.print_graphql(writer);
+            writer.write("\n");
+        }
         writer.write(self.operation_type.as_str());
         if let Some(ref name) = self.name {
             writer.write(" ");
@@ -88,6 +92,10 @@ impl GraphQLPrinter for VariablesDefinition<'_> {
 
 impl GraphQLPrinter for VariableDefinition<'_> {
     fn print_graphql(&self, writer: &mut impl SourceMapWriter) {
+        if let Some(ref description) = self.description {
+            description.print_graphql(writer);
+            writer.write(" ");
+        }
         self.name.print_graphql(writer);
         writer.write(": ");
         self.r#type.print_graphql(writer);
@@ -196,6 +204,10 @@ impl GraphQLPrinter for Selection<'_> {
 
 impl GraphQLPrinter for FragmentDefinition<'_> {
     fn print_graphql(&self, writer: &mut impl SourceMapWriter) {
+        if let Some(ref description) = self.description {
+            description.print_graphql(writer);
+            writer.write("\n");
+        }
         writer.write("fragment ");
         self.name.print_graphql(writer);
         writer.write(" on ");

--- a/crates/printer/src/operation_type_printer/tests/mod.rs
+++ b/crates/printer/src/operation_type_printer/tests/mod.rs
@@ -127,6 +127,35 @@ fn export_input_and_result_type() {
 }
 
 #[test]
+fn descriptions() {
+    let doc = parse_operation_document(
+        r#"
+        """
+        Query to get the current user.
+        """
+        query testQuery(
+            "ID of the user."
+            $foo: Int!
+            "Name of the user."
+            $bar: String
+        ) {
+            me(foo: $foo, bar: $bar) {
+                id name type age
+                ...F
+            }
+        }
+        "Fragment to get the ID."
+        fragment F on HasID {
+            id
+        }
+        "#,
+    )
+    .unwrap();
+    let printed = print_document_default(&doc);
+    assert_snapshot!(printed);
+}
+
+#[test]
 fn fragment_spread() {
     let doc = parse_operation_document(
         "

--- a/crates/printer/src/operation_type_printer/tests/snapshots/nitrogql_printer__operation_type_printer__tests__descriptions.snap
+++ b/crates/printer/src/operation_type_printer/tests/snapshots/nitrogql_printer__operation_type_printer__tests__descriptions.snap
@@ -1,0 +1,54 @@
+---
+source: crates/printer/src/operation_type_printer/tests/mod.rs
+expression: printed
+---
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import type * as Schema from "";
+
+/**
+ * Query to get the current user.
+ */
+type TestQueryResult = Schema.__SelectionSet<Schema.__OperationOutput.Query, {
+  me: Schema.__SelectionSet<Schema.__OperationOutput.User, {
+    id: Schema.__OperationOutput.ID;
+    name: Schema.__OperationOutput.String;
+    type: Schema.__OperationOutput.UserType;
+    age: Schema.__OperationOutput.Int | null;
+  }, {}>;
+}, {}>;
+
+type TestQueryVariables = {
+  /**
+   * ID of the user.
+   */
+  readonly foo: Schema.__OperationInput.Int;
+  /**
+   * Name of the user.
+   */
+  readonly bar?: Schema.__OperationInput.String | null | undefined;
+};
+
+/**
+ * Query to get the current user.
+ */
+declare const TestQueryQuery: TypedDocumentNode<TestQueryResult, TestQueryVariables>;
+
+export { TestQueryQuery as default };
+
+/**
+ * Fragment to get the ID.
+ */
+export type F = Schema.__SelectionSet<Schema.__OperationOutput.User, {
+  id: Schema.__OperationOutput.ID;
+}, {}> | Schema.__SelectionSet<Schema.__OperationOutput.Bot, {
+  id: Schema.__OperationOutput.ID;
+}, {}> | Schema.__SelectionSet<Schema.__OperationOutput.Post, {
+  id: Schema.__OperationOutput.ID;
+}, {}> | Schema.__SelectionSet<Schema.__OperationOutput.Tweet, {
+  id: Schema.__OperationOutput.ID;
+}, {}>;
+
+/**
+ * Fragment to get the ID.
+ */
+export const F: TypedDocumentNode<F, never>;

--- a/crates/printer/src/operation_type_printer/type_printer.rs
+++ b/crates/printer/src/operation_type_printer/type_printer.rs
@@ -436,7 +436,7 @@ pub fn get_type_for_variable_definitions<'src, S: Text<'src>>(
                 optional: is_optional,
                 r#type: field_type,
                 readonly: true,
-                description: None,
+                description: def.description.as_ref().map(|d| d.value.clone()),
             }])
         })
         .collect();

--- a/crates/printer/src/operation_type_printer/visitor.rs
+++ b/crates/printer/src/operation_type_printer/visitor.rs
@@ -11,6 +11,7 @@ use nitrogql_utils::clone_into;
 use sourcemap_writer::SourceMapWriter;
 
 use crate::{
+    jsdoc::print_description,
     operation_base_printer::{
         OperationPrinterVisitor, PrintFragmentContext, PrintOperationContext,
         options::OperationBasePrinterOptions,
@@ -150,6 +151,9 @@ impl OperationPrinterVisitor for OperationTypePrinterVisitor<'_, '_> {
             "{}{}",
             context.operation_names.operation_name, self.options.operation_result_type_suffix
         );
+        if let Some(ref description) = operation.description {
+            print_description(description, writer);
+        }
         if context.export_result_type {
             writer.write("export ");
         }
@@ -202,6 +206,9 @@ impl OperationPrinterVisitor for OperationTypePrinterVisitor<'_, '_> {
         input_variable_type.print_type(writer);
         writer.write(";\n\n");
 
+        if let Some(ref description) = operation.description {
+            print_description(description, writer);
+        }
         if context.exported {
             writer.write("export ");
         } else if !self.options.print_values {
@@ -240,6 +247,9 @@ impl OperationPrinterVisitor for OperationTypePrinterVisitor<'_, '_> {
     ) {
         let fragment = context.fragment;
         // type of fragment
+        if let Some(ref description) = fragment.description {
+            print_description(description, writer);
+        }
         if context.exported {
             writer.write("export ");
         }
@@ -282,6 +292,9 @@ impl OperationPrinterVisitor for OperationTypePrinterVisitor<'_, '_> {
         writer.write(";\n\n");
 
         // runtime value
+        if let Some(ref description) = fragment.description {
+            print_description(description, writer);
+        }
         if context.exported {
             writer.write("export ");
         } else if !self.options.print_values {


### PR DESCRIPTION
## Summary

The GraphQL 2025 spec added support for descriptions on executable definitions ([graphql/graphql-spec#1170](https://github.com/graphql/graphql-spec/pull/1170)): operations, fragments, and variable definitions. nitrogql previously rejected such documents with a parse error. This PR adds full support:

```graphql
"""
Query to fetch the current user.
"""
query getMe(
  "Whether to include the name."
  $withName: Boolean!
) {
  me {
    id
    name @include(if: $withName)
  }
}
```

### Changes

- **Grammar**: `Description?` is now accepted on `OperationDefinition` (only the non-shorthand form, per the spec — anonymous `{ ... }` operations cannot be described), `FragmentDefinition`, and `VariableDefinition`.
- **AST**: `OperationDefinition`, `FragmentDefinition`, and `VariableDefinition` gained a `description: Option<StringValue>` field, populated by the parser.
- **GraphQL printer**: round-trip printing emits descriptions, matching the existing behavior for type-system definitions.
- **Generated TypeScript**: descriptions surface as JSDoc, mirroring how schema descriptions are handled:
  - operation description → above the result type and the `TypedDocumentNode` constant
  - fragment description → above the fragment type and constant
  - variable description → on the corresponding property of the variables type

### Note on runtime output

Descriptions are intentionally **not** added to the runtime document (the `TypedDocumentNode` JSON emitted by the JS printer), so generated runtime output is unchanged and the documents apps send to servers remain compatible with tooling that predates the 2025 syntax.

### Tests

- Parser round-trip snapshot test covering string / block-string descriptions on operations, variables (including one with a default value and directive), and fragments.
- Operation type printer snapshot test verifying the JSDoc output.
- Verified end-to-end with the CLI: `nitrogql check` accepts the syntax and `generate` emits the JSDoc shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxgfW4ooq7SBebx3QSdqEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxgfW4ooq7SBebx3QSdqEw)_