### PR TITLE
Fix parser panic on shorthand (anonymous) query syntax

### DIFF
--- a/crates/parser/src/parser/builder/operation.rs
+++ b/crates/parser/src/parser/builder/operation.rs
@@ -57,32 +57,54 @@ pub fn build_executable_definition(pair: Pair<Rule>) -> ExecutableDefinitionExt 
     let position = pair.to_pos();
     match pair.as_rule() {
         Rule::OperationDefinition => {
-            // TODO: handling of OperationSet (abbreviated syntax)
-            let (
-                description,
-                operation_type,
-                name,
-                variables_definition,
-                directives,
-                selection_set,
-            ) = parts!(
-                pair,
-                Description opt,
-                OperationType,
-                Name opt,
-                VariablesDefinition opt,
-                Directives opt,
-                SelectionSet
-            );
-            ExecutableDefinitionExt::OperationDefinition(OperationDefinition {
-                position,
-                description: description.map(build_description),
-                operation_type: str_to_operation_type(operation_type.as_str()),
-                name: name.map(|pair| pair.to_ident()),
-                variables_definition: variables_definition.map(build_variables_definition),
-                directives: directives.map_or(vec![], build_directives),
-                selection_set: build_selection_set(selection_set),
-            })
+            // The grammar allows two forms for an OperationDefinition:
+            //   1. Description? OperationType Name? VariablesDefinition? Directives? SelectionSet
+            //   2. SelectionSet  (shorthand / anonymous query syntax, e.g. `{ foo bar }`)
+            // In the shorthand form the only child is a SelectionSet, and the operation
+            // is treated as an anonymous, untyped `query`.
+            let is_shorthand = pair
+                .clone()
+                .into_inner()
+                .next()
+                .is_some_and(|first| first.is_rule(Rule::SelectionSet));
+            if is_shorthand {
+                let selection_set = pair.only_child();
+                ExecutableDefinitionExt::OperationDefinition(OperationDefinition {
+                    position,
+                    description: None,
+                    operation_type: OperationType::Query,
+                    name: None,
+                    variables_definition: None,
+                    directives: vec![],
+                    selection_set: build_selection_set(selection_set),
+                })
+            } else {
+                let (
+                    description,
+                    operation_type,
+                    name,
+                    variables_definition,
+                    directives,
+                    selection_set,
+                ) = parts!(
+                    pair,
+                    Description opt,
+                    OperationType,
+                    Name opt,
+                    VariablesDefinition opt,
+                    Directives opt,
+                    SelectionSet
+                );
+                ExecutableDefinitionExt::OperationDefinition(OperationDefinition {
+                    position,
+                    description: description.map(build_description),
+                    operation_type: str_to_operation_type(operation_type.as_str()),
+                    name: name.map(|pair| pair.to_ident()),
+                    variables_definition: variables_definition.map(build_variables_definition),
+                    directives: directives.map_or(vec![], build_directives),
+                    selection_set: build_selection_set(selection_set),
+                })
+            }
         }
         Rule::FragmentDefinition => {
             let (description, _, name, type_condition, directives, selection_set) = parts!(

--- a/crates/parser/src/tests/mod.rs
+++ b/crates/parser/src/tests/mod.rs
@@ -13,6 +13,12 @@ mod operation {
         ))
     }
     #[test]
+    fn shorthand_query() {
+        assert_snapshot!(print_graphql(
+            parse_operation_document("{ foo bar }").unwrap()
+        ))
+    }
+    #[test]
     fn query_with_name() {
         assert_snapshot!(print_graphql(
             parse_operation_document(

--- a/crates/parser/src/tests/snapshots/nitrogql_parser__tests__operation__shorthand_query.snap
+++ b/crates/parser/src/tests/snapshots/nitrogql_parser__tests__operation__shorthand_query.snap
@@ -1,0 +1,8 @@
+---
+source: crates/parser/src/tests/mod.rs
+expression: "print_graphql(parse_operation_document(\"{ foo bar }\").unwrap())"
+---
+query {
+  foo
+  bar
+}


### PR DESCRIPTION
Fixes #82.

## Problem

Parsing an executable document that uses GraphQL's shorthand query syntax (an anonymous query with no leading `query` keyword, e.g. `{ foo bar }`) panicked instead of returning a result:

```
thread 'main' panicked at crates/parser/src/parser/builder/operation.rs:68:17:
Expected OperationType, actual SelectionSet
```

The `OperationDefinition` grammar rule allows two alternatives — the full `Description? OperationType Name? VariablesDefinition? Directives? SelectionSet` form and a bare `SelectionSet` (the shorthand form). But the builder always destructured the pair with a required (non-`opt`) `OperationType` slot, so the shorthand form — which has no `OperationType` child — hit the `panic!` arm in `parts_mod!`, crashing the whole process (e.g. `nitrogql check`/`generate` or any `@nitrogql/graphql-loader` consumer bundling such a query).

## Fix

In `crates/parser/src/parser/builder/operation.rs`, detect the shorthand form (the `OperationDefinition`'s only child is a `SelectionSet`) and build it as an anonymous, untyped `query` operation — `operation_type: Query`, with no name, variables, directives, or description. The existing path is unchanged for the full form.

Since the grammar's shorthand alternative is a bare `SelectionSet`, a description is structurally impossible on a shorthand query, which matches the spec (descriptions are forbidden on shorthand queries).

## Testing

- Added a `shorthand_query` parser test (`{ foo bar }` parses and prints as `query { foo bar }`) with its insta snapshot.
- Full workspace test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrVBC4w7eXF5MepyujxZca

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrVBC4w7eXF5MepyujxZca)_