### PR TITLE
Fix GraphQL printer dropping default value and directives for VariableDefinition

### DIFF
--- a/crates/parser/src/tests/snapshots/nitrogql_parser__tests__operation__descriptions.snap
+++ b/crates/parser/src/tests/snapshots/nitrogql_parser__tests__operation__descriptions.snap
@@ -7,7 +7,7 @@ query sample(
   "This is a variable." $foo: Int!,
   """
                       This is another variable.
-                      """ $bar: String
+                      """ $bar: String = "bar" @deprecated
 ) {
   foo
   ... F

--- a/crates/printer/src/graphql_printer/ast.rs
+++ b/crates/printer/src/graphql_printer/ast.rs
@@ -99,6 +99,14 @@ impl GraphQLPrinter for VariableDefinition<'_> {
         self.name.print_graphql(writer);
         writer.write(": ");
         self.r#type.print_graphql(writer);
+        if let Some(ref default_value) = self.default_value {
+            writer.write(" = ");
+            default_value.print_graphql(writer);
+        }
+        for d in self.directives.iter() {
+            writer.write(" ");
+            d.print_graphql(writer);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`VariableDefinition::print_graphql` only emitted the description, name, and type of a variable definition — it silently dropped the `default_value` and `directives`, even though both are carried on the AST node (`crates/ast/src/variable.rs`).

This fix prints the default value and directives after the type, following the same pattern already used by `InputValueDefinition` elsewhere in `crates/printer/src/graphql_printer/ast.rs`:

```rust
self.r#type.print_graphql(writer);
if let Some(ref default_value) = self.default_value {
    writer.write(" = ");
    default_value.print_graphql(writer);
}
for d in self.directives.iter() {
    writer.write(" ");
    d.print_graphql(writer);
}
```

## Testing

The feature's own snapshot (`nitrogql_parser__tests__operation__descriptions.snap`) demonstrated the bug: an input variable definition of `$bar: String = "bar" @deprecated` round-tripped through the printer as just `$bar: String`, losing both the default value and the directive. The snapshot has been regenerated and now correctly preserves `$bar: String = "bar" @deprecated`.

Full test suite passes.

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNnPGRQURCbBQtXY1cVw3R)_